### PR TITLE
herdr backend: extend the multiplexer registry to herdr (tmux + zellij + herdr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 **Claude Code · Codex CLI · Grok · Qwen · Kimi · OpenCode · Antigravity** — when they hit the 5-hour or weekly usage limit
 ("You've hit your usage limit"), your session just… stops.<br/>
 unsnooze auto-resumes them: it tracks **every** limit-stopped session across all
-your projects and **wakes each one up in tmux or Zellij the moment the usage limit resets.**
+your projects and **wakes each one up in tmux, Zellij, or herdr the moment the usage limit resets.**
 
 ```sh
 npm install -g unsnooze && unsnooze setup
@@ -147,7 +147,7 @@ surfaced as a notification — there's no reset to wait for, only a top-up.
 
 ## GUI surfaces (VS Code extension, desktop apps)
 
-Terminal sessions are watched through the shell wrapper + tmux or Zellij. Sessions in
+Terminal sessions are watched through the shell wrapper + tmux, Zellij, or herdr. Sessions in
 **Claude Code's VS Code extension / desktop app** and **Codex's IDE
 extension / desktop app** have no pane to scrape — so `unsnooze daemon` tails
 the session files those surfaces already write:
@@ -400,7 +400,8 @@ pressing **`R`** (uppercase — lowercase `r` refreshes) only marks it due — t
 remote's own daemon does the actual keystrokes, under the same
 ownership/liveness/menu gates as a local session.
 Resumed and stopped sessions print an attach hint
-(`ssh -t <host> 'tmux new -A -s <session>'` / `zellij attach <session>`) so
+(`ssh -t <host> 'tmux new -A -s <session>'` / `zellij attach <session>` /
+`ssh -t <host> 'herdr session attach <session>'`) so
 you can hop over and watch. An unreachable or out-of-date host shows
 `unreachable`/`skew` rather than blocking the rest of the fleet, and falls
 back to its last-known state (marked `stale`) for up to 24h.
@@ -491,7 +492,7 @@ password hosts on Windows; a plain `ssh <host>` prompt works with native
 
 | key | default | meaning |
 |---|---|---|
-| `multiplexer` | `auto` | Backend to use: `auto`, `tmux`, or `zellij`. `auto` prefers the current multiplexer, then the only installed backend, with tmux as the tie-breaker. |
+| `multiplexer` | `auto` | Backend to use: `auto`, `tmux`, `zellij`, or `herdr`. `auto` prefers the current multiplexer, then the only installed backend, with tmux as the tie-breaker. |
 | `autoResume` | `true` | Master switch. Off = stops are still tracked, but nothing is resumed until you run `unsnooze resume-now` or turn it back on. |
 | `menuAutoAnswer` | `true` | May unsnooze answer Claude's limit menu (send keys in your pane)? Off = watch-only. |
 | `notifications` | `true` | Master switch for all notifications (limit detected / session resumed / gave up). Off = silence every channel. |
@@ -596,26 +597,28 @@ watcher stops (no pane context) always use native.
 
 ## Requirements
 
-- Node ≥ 20 and tmux ≥ 3.2 **or** Zellij
+- Node ≥ 20 and tmux ≥ 3.2, Zellij, **or** herdr ≥ 0.7.5
 - macOS, Linux, or **Windows via WSL** (see below)
 - zsh or bash (the wrappers are installed into `~/.zshrc` / `~/.bashrc`)
 
 ### Windows / WSL
 
-tmux and Zellij are Unix tools, so on Windows unsnooze runs inside
+tmux, Zellij, and herdr are Unix tools, so on Windows unsnooze runs inside
 [WSL](https://learn.microsoft.com/windows/wsl/install) — which is where the
 agent CLIs live on Windows anyway:
 
 ```sh
 # inside your WSL distro (Ubuntu etc.)
 sudo apt install tmux             # or install Zellij: https://zellij.dev/documentation/installation
+# install herdr from https://herdr.dev (requires herdr >= 0.7.5)
 npm install -g unsnooze && unsnooze setup
 ```
 
 On macOS, install either backend with `brew install tmux` or
-`brew install zellij`. In `auto` mode unsnooze uses the multiplexer you are
-currently inside; choose one explicitly with
-`unsnooze config set multiplexer tmux` or `zellij`.
+`brew install zellij`; install herdr from [herdr.dev](https://herdr.dev).
+herdr >= 0.7.5 (socket protocol 17); older 0.x releases are untested and refused by available().
+In `auto` mode unsnooze uses the multiplexer you are currently inside; choose one
+explicitly with `unsnooze config set multiplexer tmux`, `zellij`, or `herdr`.
 
 Everything works as on Linux, including desktop notifications: inside WSL,
 unsnooze raises **native Windows toasts** through `powershell.exe` (no
@@ -694,6 +697,7 @@ npm test                     # unit tests (node:test)
 ./scripts/e2e-simulate.sh    # full detect → wait → re-open cycle in a
                              # scratch tmux session (no real limits needed)
 bash -n scripts/e2e-zellij.sh # syntax-check the reserved-session Zellij smoke test
+bash scripts/e2e-herdr.sh     # headless Herdr smoke test (scratch --session)
 vhs demo/demo.tape           # regenerate assets/demo.gif (brew install vhs)
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unsnooze",
   "version": "1.14.0",
-  "description": "Auto-resume Claude Code, Codex CLI, Grok, Qwen Code, Kimi CLI, OpenCode & Antigravity when the 5-hour/weekly usage limit resets \u2014 tmux, Zellij, VS Code & desktop apps. Wakes every limit-stopped AI coding session automatically.",
+  "description": "Auto-resume Claude Code, Codex CLI, Grok, Qwen Code, Kimi CLI, OpenCode & Antigravity when the 5-hour/weekly usage limit resets \u2014 tmux, Zellij, herdr, VS Code & desktop apps. Wakes every limit-stopped AI coding session automatically.",
   "keywords": [
     "claude",
     "claude-code",
@@ -35,6 +35,7 @@
     "retry",
     "tmux",
     "zellij",
+    "herdr",
     "ai-agents",
     "agentic-coding",
     "cli",

--- a/scripts/e2e-herdr.sh
+++ b/scripts/e2e-herdr.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Live Herdr primitive smoke test. This never launches a real agent and owns
+# only the unique throwaway session below.
+set -uo pipefail
+
+SESSION="unsnooze-e2e-$$"
+CONFIG_ROOT="${TMPDIR:-/tmp}/unsnooze-herdr-e2e-$$"
+CREATED=0
+FAILURES=0
+mkdir -p "$CONFIG_ROOT"
+export XDG_CONFIG_HOME="$CONFIG_ROOT"
+
+# Deliberately poison inherited pane context. Every Herdr invocation below
+# removes these variables and supplies the scratch session explicitly.
+export HERDR_ENV='conflicting-herdr-context'
+export HERDR_PANE_ID='w999:p999'
+export HERDR_SOCKET_PATH='/tmp/conflicting-herdr.sock'
+export HERDR_TAB_ID='w999:t999'
+export HERDR_WORKSPACE_ID='w999'
+
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; FAILURES=$((FAILURES + 1)); }
+
+herdr_session() (
+  env -u HERDR_ENV -u HERDR_PANE_ID -u HERDR_SOCKET_PATH \
+    -u HERDR_TAB_ID -u HERDR_WORKSPACE_ID \
+    herdr --session "$SESSION" "$@"
+)
+
+json_has_session() {
+  local expected=$1
+  node -e '
+    let s = "";
+    process.stdin.on("data", c => s += c).on("end", () => {
+      try {
+        const expected = process.argv[1];
+        const rows = JSON.parse(s)?.sessions || [];
+        process.exit(rows.some(row => row.name === expected) ? 0 : 1);
+      } catch { process.exit(1); }
+    });
+  ' "$expected"
+}
+
+json_session_running() {
+  local expected=$1
+  node -e '
+    let s = "";
+    process.stdin.on("data", c => s += c).on("end", () => {
+      try {
+        const expected = process.argv[1];
+        const rows = JSON.parse(s)?.sessions || [];
+        process.exit(rows.some(row => row.name === expected && row.running === true) ? 0 : 1);
+      } catch { process.exit(1); }
+    });
+  ' "$expected"
+}
+
+json_root_pane() {
+  node -e '
+    let s = "";
+    process.stdin.on("data", c => s += c).on("end", () => {
+      try {
+        const pane = JSON.parse(s)?.result?.root_pane?.pane_id;
+        if (pane) process.stdout.write(String(pane));
+      } catch {}
+    });
+  '
+}
+
+json_has_pane() {
+  local expected=$1
+  node -e '
+    let s = "";
+    process.stdin.on("data", c => s += c).on("end", () => {
+      try {
+        const expected = process.argv[1];
+        const parsed = JSON.parse(s);
+        const rows = parsed?.result?.panes || parsed?.panes || [];
+        process.exit(rows.some(row => String(row?.pane_id ?? row?.id ?? row) === expected) ? 0 : 1);
+      } catch { process.exit(1); }
+    });
+  ' "$expected"
+}
+
+json_pane_id() {
+  local expected=$1
+  node -e '
+    let s = "";
+    process.stdin.on("data", c => s += c).on("end", () => {
+      try {
+        const expected = process.argv[1];
+        const pane = JSON.parse(s)?.result?.pane?.pane_id;
+        process.exit(String(pane) === expected ? 0 : 1);
+      } catch { process.exit(1); }
+    });
+  ' "$expected"
+}
+
+json_pane_not_found() {
+  node -e '
+    let s = "";
+    process.stdin.on("data", c => s += c).on("end", () => {
+      try { process.exit(JSON.parse(s)?.error?.code === "pane_not_found" ? 0 : 1); }
+      catch { process.exit(1); }
+    });
+  '
+}
+
+cleanup() {
+  if (( CREATED )); then
+    herdr_session session stop "$SESSION" >/dev/null 2>&1 || true
+    herdr_session session delete "$SESSION" >/dev/null 2>&1 || true
+  fi
+  rm -rf -- "$CONFIG_ROOT"
+}
+trap cleanup EXIT
+
+if ! command -v herdr >/dev/null 2>&1; then
+  fail 'herdr is installed'
+  exit 1
+fi
+pass 'herdr is installed'
+
+version=$(herdr_session --version 2>/dev/null || true)
+if [[ $version =~ herdr[[:space:]]([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+  major=${BASH_REMATCH[1]}
+  minor=${BASH_REMATCH[2]}
+  patch=${BASH_REMATCH[3]}
+  if (( major > 0 || (major == 0 && (minor > 7 || (minor == 7 && patch >= 5))) )); then
+    pass "version gate accepts $version"
+  else
+    fail "version gate accepts herdr >= 0.7.5 (got '${version:-empty}')"
+    exit 1
+  fi
+else
+  fail "version gate returned herdr >= 0.7.5 (got '${version:-empty}')"
+  exit 1
+fi
+
+# Refuse to touch a pre-existing session, even though the name includes $$.
+existing=$(herdr_session session list --json 2>/dev/null || true)
+if printf '%s' "$existing" | json_has_session "$SESSION"; then
+  fail "throwaway session '$SESSION' already exists; refusing to touch it"
+  exit 1
+fi
+pass "throwaway session '$SESSION' is unused"
+
+if ! command -v setsid >/dev/null 2>&1; then
+  fail 'setsid is installed for detached headless start'
+  exit 1
+fi
+
+CREATED=1
+if setsid env -u HERDR_ENV -u HERDR_PANE_ID -u HERDR_SOCKET_PATH \
+    -u HERDR_TAB_ID -u HERDR_WORKSPACE_ID \
+    herdr --session "$SESSION" server >/dev/null 2>&1 &
+then
+  server_started=1
+else
+  server_started=0
+fi
+
+sessions_json=''
+running=0
+if (( server_started )); then
+  for _ in {1..40}; do
+    sessions_json=$(herdr_session session list --json 2>/dev/null || true)
+    if printf '%s' "$sessions_json" | json_session_running "$SESSION"; then
+      running=1
+      break
+    fi
+    sleep 0.1
+  done
+fi
+if (( running )); then
+  pass "headless session '$SESSION' is running"
+else
+  fail "headless session '$SESSION' is running"
+  exit 1
+fi
+
+workspace_json=$(herdr_session workspace create --cwd /tmp --label unsnooze-e2e 2>/dev/null || true)
+root_pane=$(printf '%s' "$workspace_json" | json_root_pane)
+if [[ -n $root_pane ]]; then
+  pass "workspace create returned root pane '$root_pane'"
+else
+  fail 'workspace create returned result.root_pane.pane_id'
+  exit 1
+fi
+
+run_rc=0
+herdr_session pane run "$root_pane" /usr/bin/printf '__UNSNOOZE_HERDR_RUN__\\n' >/dev/null 2>&1 || run_rc=$?
+if (( run_rc == 0 )); then
+  run_seen=0
+  for _ in {1..20}; do
+    screen=$(herdr_session pane read "$root_pane" --source recent --lines 20 --format text 2>/dev/null || true)
+    if [[ $screen == *'__UNSNOOZE_HERDR_RUN__'* ]]; then run_seen=1; break; fi
+    sleep 0.1
+  done
+  if (( run_seen )); then
+    pass 'pane run command output was visible in pane read'
+  else
+    fail 'pane run command output was visible in pane read'
+  fi
+else
+  fail 'pane run command succeeded'
+fi
+
+if panes_json=$(herdr_session pane list 2>/dev/null) \
+    && printf '%s' "$panes_json" | json_has_pane "$root_pane"; then
+  pass "listSessionPanes found '$root_pane'"
+else
+  fail "listSessionPanes found '$root_pane'"
+fi
+
+if herdr_session pane send-text "$root_pane" 'echo __UNSNOOZE_HERDR_SEND__' >/dev/null 2>&1 \
+    && herdr_session pane send-keys "$root_pane" enter >/dev/null 2>&1; then
+  send_seen=0
+  for _ in {1..20}; do
+    screen=$(herdr_session pane read "$root_pane" --source recent --lines 30 --format text 2>/dev/null || true)
+    if [[ $screen == *'__UNSNOOZE_HERDR_SEND__'* ]]; then send_seen=1; break; fi
+    sleep 0.1
+  done
+  if (( send_seen )); then
+    pass 'send-text + send-keys enter round-trip appeared in pane read'
+  else
+    fail 'send-text + send-keys enter round-trip appeared in pane read'
+  fi
+else
+  fail 'send-text + send-keys enter round-trip was accepted'
+fi
+
+pane_json=$(herdr_session pane get "$root_pane" 2>/dev/null || true)
+if printf '%s' "$pane_json" | json_pane_id "$root_pane"; then
+  pass "paneAlive true for '$root_pane'"
+else
+  fail "paneAlive true for '$root_pane'"
+fi
+
+close_rc=0
+herdr_session pane close "$root_pane" >/dev/null 2>&1 || close_rc=$?
+if (( close_rc == 0 )); then
+  pass "closed pane '$root_pane'"
+else
+  fail "closed pane '$root_pane'"
+fi
+
+not_found_rc=0
+not_found=$(herdr_session pane get "$root_pane" 2>&1) || not_found_rc=$?
+if (( not_found_rc != 0 )) && printf '%s' "$not_found" | json_pane_not_found; then
+  pass "paneAlive false after close ('$root_pane' is pane_not_found)"
+else
+  fail "paneAlive false after close ('$root_pane' is pane_not_found)"
+fi
+
+sessions_json=$(herdr_session session list --json 2>/dev/null || true)
+if printf '%s' "$sessions_json" | json_session_running "$SESSION"; then
+  pass "session list reports '$SESSION' before stop"
+else
+  fail "session list reports '$SESSION' before stop"
+fi
+
+stop_rc=0
+herdr_session session stop "$SESSION" >/dev/null 2>&1 || stop_rc=$?
+if (( stop_rc == 0 )); then
+  pass "stopped session '$SESSION'"
+else
+  fail "stopped session '$SESSION'"
+fi
+
+delete_rc=0
+herdr_session session delete "$SESSION" >/dev/null 2>&1 || delete_rc=$?
+if (( delete_rc == 0 )); then
+  pass "deleted session '$SESSION'"
+else
+  fail "deleted session '$SESSION'"
+fi
+if (( stop_rc == 0 && delete_rc == 0 )); then CREATED=0; fi
+
+if (( FAILURES > 0 )); then
+  printf 'FAIL: %d check(s) failed\n' "$FAILURES" >&2
+  exit 1
+fi
+
+printf 'PASS: all Herdr smoke checks passed\n'

--- a/src/fleet.js
+++ b/src/fleet.js
@@ -845,7 +845,8 @@ export const MUX_SESSION_RE = /^[A-Za-z0-9_.-]{1,64}$/;
 // validation — callers must treat null as "omit the attach line".
 export function attachHintRemote(dest, muxName, muxSession) {
   if (!validHostToken(dest) || typeof muxSession !== 'string' || !MUX_SESSION_RE.test(muxSession)) return null;
-  const inner = muxName === 'zellij' ? `zellij attach ${muxSession}` : `tmux new -A -s ${muxSession}`;
+  const inner = muxName === 'herdr' ? `herdr session attach ${muxSession}`
+    : muxName === 'zellij' ? `zellij attach ${muxSession}` : `tmux new -A -s ${muxSession}`;
   return `ssh -t ${dest} '${inner}'`;
 }
 

--- a/src/hook.js
+++ b/src/hook.js
@@ -40,6 +40,21 @@ function classify(payload, raw) {
   return 'unknown';
 }
 
+export function hookContext(env = process.env, payload = {}) {
+  const managedMux = env.UNSNOOZE_MUX;
+  const muxName = managedMux || (env.HERDR_PANE_ID ? 'herdr' : env.ZELLIJ_PANE_ID ? 'zellij' : 'tmux');
+  const pane = managedMux
+    ? (env.UNSNOOZE_PANE || null)
+    : (muxName === 'herdr' ? env.HERDR_PANE_ID
+      : muxName === 'zellij' ? env.ZELLIJ_PANE_ID : env.TMUX_PANE || payload.tmux_pane) || null;
+  const paneOwner = muxName === 'herdr'
+    ? (managedMux ? env.UNSNOOZE_PANE_OWNER : (env.HERDR_SESSION || 'default'))
+    : muxName === 'zellij'
+      ? (managedMux ? env.UNSNOOZE_PANE_OWNER : env.ZELLIJ_SESSION_NAME) || null
+      : null;
+  return { muxName, pane, paneOwner };
+}
+
 export async function runHook(rest = []) {
   try {
     const agentIdx = rest.indexOf('--agent');
@@ -49,14 +64,7 @@ export async function runHook(rest = []) {
     let payload = {};
     try { payload = JSON.parse(raw); } catch { /* tolerate non-JSON */ }
 
-    const managedMux = process.env.UNSNOOZE_MUX;
-    const muxName = managedMux || (process.env.ZELLIJ_PANE_ID ? 'zellij' : 'tmux');
-    const pane = managedMux
-      ? (process.env.UNSNOOZE_PANE || null)
-      : (muxName === 'zellij' ? process.env.ZELLIJ_PANE_ID : process.env.TMUX_PANE || payload.tmux_pane) || null;
-    const paneOwner = muxName === 'zellij'
-      ? (managedMux ? process.env.UNSNOOZE_PANE_OWNER : process.env.ZELLIJ_SESSION_NAME) || null
-      : null;
+    const { muxName, pane, paneOwner } = hookContext(process.env, payload);
     const leaseId = process.env.UNSNOOZE_LEASE_ID || null;
     const mux = getMultiplexer(muxName, { owner: paneOwner });
     const kind = classify(payload, raw);

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -19,6 +19,18 @@ function isPrintMode(args) {
   return args.includes('-p') || args.includes('--print');
 }
 
+export function resolvePaneOwner(muxName, env = process.env) {
+  if (muxName === 'herdr') {
+    return (env.UNSNOOZE_MUX === 'herdr'
+      ? env.UNSNOOZE_PANE_OWNER : env.HERDR_SESSION || 'default') || null;
+  }
+  if (muxName === 'zellij') {
+    return (env.UNSNOOZE_MUX === 'zellij'
+      ? env.UNSNOOZE_PANE_OWNER : env.ZELLIJ_SESSION_NAME) || null;
+  }
+  return null;
+}
+
 function runUnwatched(agent, args, reason) {
   if (reason) process.stderr.write(`unsnooze: ${reason}\n`);
   const r = spawnSync(agent.bin, args, { stdio: 'inherit', env: { ...process.env, UNSNOOZE_ACTIVE: '1' } });
@@ -68,10 +80,7 @@ export function runLauncher(args, agentId = 'claude') {
   }
 
   const pane = mux.currentPaneId();
-  const paneOwner = mux.name === 'zellij'
-    ? (process.env.UNSNOOZE_MUX === 'zellij'
-      ? process.env.UNSNOOZE_PANE_OWNER : process.env.ZELLIJ_SESSION_NAME) || null
-    : null;
+  const paneOwner = resolvePaneOwner(mux.name, process.env);
   const leaseId = process.env.UNSNOOZE_LEASE_ID || createLeaseId();
   if (pane) {
     // Stamp our own pane (best-effort, tmux only): the identity every later

--- a/src/multiplexer.js
+++ b/src/multiplexer.js
@@ -1,11 +1,12 @@
 import tmux from './multiplexers/tmux.js';
 import zellij from './multiplexers/zellij.js';
+import herdr from './multiplexers/herdr.js';
 import { getConfig } from './settings.js';
 
-const NAMES = ['tmux', 'zellij'];
+const NAMES = ['tmux', 'zellij', 'herdr'];
 
 export function createMultiplexerFactory({
-  backends = { tmux, zellij },
+  backends = { tmux, zellij, herdr },
   getSetting = () => getConfig('multiplexer'),
   env = process.env,
 } = {}) {
@@ -30,12 +31,17 @@ export function createMultiplexerFactory({
     try { configured = getSetting() || 'auto'; } catch { /* pre-setting compatibility */ }
     if (configured !== 'auto') return configured;
 
+    if (env.HERDR_ENV) return 'herdr';
     if (env.ZELLIJ) return 'zellij';
     if (env.TMUX) return 'tmux';
 
     const tmuxInstalled = isAvailable('tmux');
     const zellijInstalled = isAvailable('zellij');
-    if (tmuxInstalled !== zellijInstalled) return tmuxInstalled ? 'tmux' : 'zellij';
+    const herdrInstalled = isAvailable('herdr');
+    const installed = [
+      ['tmux', tmuxInstalled], ['zellij', zellijInstalled], ['herdr', herdrInstalled],
+    ].filter(([, present]) => present).map(([name]) => name);
+    if (installed.length === 1) return installed[0];
     return 'tmux';
   };
 

--- a/src/multiplexers/herdr.js
+++ b/src/multiplexers/herdr.js
@@ -2,6 +2,10 @@
 // remains alive with its shell prompt. The resumer must therefore verify
 // agent ownership before injecting, and revival can reuse a surviving pane
 // only when Task 3 wires that path deliberately.
+// Launch env is delivered via workspace create --env, whitelisted to
+// UNSNOOZE_* because pane run types argv into the pane shell. Non-UNSNOOZE
+// env reaches the pane via the session server's inherited environment,
+// matching tmux server-env semantics.
 
 import { execFile as execFileCb, spawn, spawnSync } from 'node:child_process';
 import { constants as osConstants } from 'node:os';
@@ -33,11 +37,10 @@ function scrubHerdrEnv(env) {
   return Object.fromEntries(Object.entries(env).filter(([key]) => !key.startsWith('HERDR')));
 }
 
-function launchArgv({ file, args = [], env = {} }) {
-  const assignments = Object.entries(env)
-    .filter(([, value]) => value !== undefined)
-    .map(([key, value]) => `${key}=${value}`);
-  return ['/usr/bin/env', ...assignments, file, ...args];
+function envFlags(env = {}) {
+  return Object.entries(env)
+    .filter(([key, value]) => /^UNSNOOZE_/.test(key) && value !== undefined)
+    .flatMap(([key, value]) => ['--env', `${key}=${value}`]);
 }
 
 function exitStatus(result) {
@@ -357,10 +360,11 @@ export function createHerdr({ spawner = defaultSpawner, env = process.env } = {}
         await ensureSessionRunning(sessionName);
         const workspace = parseResult(await inSession(
           sessionName, 'workspace', 'create', '--cwd', cwd, '--label', 'unsnooze',
+          ...envFlags(launchSpec?.env),
         ));
         const pane = workspace?.root_pane?.pane_id;
         if (!pane) throw new Error('unsnooze: unexpected herdr workspace shape: no root_pane');
-        await inSession(sessionName, 'pane', 'run', String(pane), ...launchArgv(launchSpec));
+        await inSession(sessionName, 'pane', 'run', String(pane), launchSpec.file, ...(launchSpec.args || []));
         return { pane: String(pane), paneOwner: sessionName };
       },
 
@@ -371,11 +375,12 @@ export function createHerdr({ spawner = defaultSpawner, env = process.env } = {}
           ensureSessionRunningSync(name);
           const workspace = parseResult(syncCall([
             '--session', name, 'workspace', 'create', '--cwd', process.cwd(), '--label', 'unsnooze',
+            ...envFlags(launchSpec?.env),
           ], name, 'create workspace'));
           const pane = workspace?.root_pane?.pane_id;
           if (!pane) throw new Error('unsnooze: unexpected herdr workspace shape: no root_pane');
           syncCall([
-            '--session', name, 'pane', 'run', String(pane), ...launchArgv(launchSpec),
+            '--session', name, 'pane', 'run', String(pane), launchSpec.file, ...(launchSpec.args || []),
           ], name, 'run pane');
         } catch (error) {
           if (error instanceof SessionCreateError) throw error;

--- a/src/multiplexers/herdr.js
+++ b/src/multiplexers/herdr.js
@@ -1,0 +1,213 @@
+import { execFile as execFileCb, spawnSync } from 'node:child_process';
+import { basename } from 'node:path';
+import { promisify } from 'node:util';
+
+import { SessionCreateError } from './session-name.js';
+
+const execFileAsync = promisify(execFileCb);
+const MIN_VERSION = [0, 7, 5];
+
+function defaultSpawner(file, args, { sync = false, ...options } = {}) {
+  if (sync) return spawnSync(file, args, options);
+  return execFileAsync(file, args, options).then(({ stdout }) => stdout);
+}
+
+function scrubHerdrEnv(env) {
+  return Object.fromEntries(Object.entries(env).filter(([key]) => !key.startsWith('HERDR')));
+}
+
+function parseResult(stdout) {
+  const parsed = JSON.parse(String(stdout));
+  return (parsed && typeof parsed === 'object' && 'result' in parsed) ? parsed.result : parsed;
+}
+
+function parseVersion(stdout) {
+  const match = String(stdout).match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function versionAtLeast(actual, floor) {
+  for (let index = 0; index < floor.length; index += 1) {
+    const value = actual[index] ?? 0;
+    if (value !== floor[index]) return value > floor[index];
+  }
+  return true;
+}
+
+const KEY_MAP = {
+  Escape: 'esc',
+  Enter: 'enter',
+  Tab: 'tab',
+  Backspace: 'backspace',
+  Down: 'down',
+  Up: 'up',
+  Right: 'right',
+  Left: 'left',
+};
+
+export const SUBMIT_DELAY_MS = 150;
+
+export { SessionCreateError };
+
+export function createHerdr({ spawner = defaultSpawner, env = process.env } = {}) {
+  const childEnv = () => scrubHerdrEnv(env);
+  const run = (args, options = {}) => spawner('herdr', args, { env: childEnv(), ...options });
+
+  const build = owner => {
+    const owned = (...args) => {
+      if (!owner) throw new Error('unsnooze: herdr pane operation requires a session owner');
+      return run(['--session', owner, ...args]);
+    };
+    const inSession = (session, ...args) => {
+      if (!session) throw new Error('unsnooze: herdr pane operation requires a session owner');
+      return run(['--session', session, ...args]);
+    };
+
+    const backend = {
+      name: 'herdr',
+      owner,
+      SUBMIT_DELAY_MS,
+
+      available() {
+        try {
+          const result = spawner('herdr', ['--version'], {
+            sync: true,
+            encoding: 'utf8',
+            env: childEnv(),
+          });
+          if (result.status !== 0) return false;
+          const version = parseVersion(result.stdout);
+          return !!version && versionAtLeast(version, MIN_VERSION);
+        } catch {
+          return false;
+        }
+      },
+
+      inside() {
+        return !!(env.HERDR_ENV || env.HERDR_PANE_ID);
+      },
+
+      currentPaneId() {
+        if (env.UNSNOOZE_MUX === 'herdr' && env.UNSNOOZE_PANE) return env.UNSNOOZE_PANE;
+        return env.HERDR_PANE_ID || null;
+      },
+
+      async capturePane(pane, lines = 200) {
+        return owned('pane', 'read', String(pane),
+          '--source', 'recent', '--lines', String(lines), '--format', 'text');
+      },
+
+      async capturePaneVisible(pane) {
+        return owned('pane', 'read', String(pane), '--source', 'visible', '--format', 'text');
+      },
+
+      async sendText(pane, text) {
+        await owned('pane', 'send-text', String(pane), text);
+        await new Promise(resolve => setTimeout(resolve, SUBMIT_DELAY_MS));
+        await owned('pane', 'send-keys', String(pane), 'enter');
+      },
+
+      async sendKey(pane, key) {
+        const named = KEY_MAP[key];
+        if (named) {
+          await owned('pane', 'send-keys', String(pane), named);
+          return;
+        }
+        await owned('pane', 'send-text', String(pane), key);
+      },
+
+      async paneAlive(pane) {
+        try {
+          const result = parseResult(await owned('pane', 'get', String(pane)));
+          return result?.pane?.pane_id === String(pane);
+        } catch {
+          return false;
+        }
+      },
+
+      async sessionForPane(_pane) {
+        if (owner) return owner;
+        if (env.HERDR_SESSION) return env.HERDR_SESSION;
+        return backend.inside() ? 'default' : null;
+      },
+
+      async paneCurrentCommand(pane) {
+        try {
+          const info = parseResult(
+            await owned('pane', 'process-info', '--pane', String(pane)),
+          )?.process_info;
+          const processes = info?.foreground_processes;
+          if (!Array.isArray(processes) || processes.length === 0) return null;
+          const foreground = processes.find(process =>
+            process.pid === info.foreground_process_group_id) || processes[0];
+          if (Array.isArray(foreground.argv) && foreground.argv[0]) {
+            return basename(foreground.argv[0].split(/\s+/)[0]);
+          }
+          return foreground.name ? basename(foreground.name) : null;
+        } catch {
+          return null;
+        }
+      },
+
+      async sessionExists(name) {
+        try {
+          return (await backend.listSessions()).some(row => row.name === name);
+        } catch {
+          return false;
+        }
+      },
+
+      async listSessions() {
+        try {
+          const result = parseResult(await run(['session', 'list', '--json']));
+          const rows = Array.isArray(result?.sessions) ? result.sessions : [];
+          return rows
+            .filter(row => typeof row?.name === 'string' && row.name)
+            .map(row => ({ name: row.name, exited: row.running === false }));
+        } catch {
+          return [];
+        }
+      },
+
+      async listSessionPanes(sessionName) {
+        try {
+          const result = parseResult(await inSession(sessionName, 'pane', 'list'));
+          const panes = Array.isArray(result?.panes) ? result.panes : [];
+          return panes.map(entry => String(entry.pane_id)).filter(Boolean);
+        } catch {
+          return [];
+        }
+      },
+
+      async closePane(pane) {
+        await owned('pane', 'close', String(pane));
+      },
+
+      async deleteSession(name) {
+        try {
+          await run(['session', 'stop', name]);
+        } catch {
+          // The session may already be stopped or unreachable.
+        }
+        await run(['session', 'delete', name]);
+      },
+
+      bind(nextOwner) {
+        return build(nextOwner);
+      },
+    };
+
+    return backend;
+  };
+
+  return build(null);
+}
+
+const herdr = createHerdr();
+
+export const available = (...args) => herdr.available(...args);
+export const inside = (...args) => herdr.inside(...args);
+export const currentPaneId = (...args) => herdr.currentPaneId(...args);
+
+export default herdr;

--- a/src/multiplexers/herdr.js
+++ b/src/multiplexers/herdr.js
@@ -1,19 +1,52 @@
-import { execFile as execFileCb, spawnSync } from 'node:child_process';
+// herdr panes have no close-on-exit: when an agent command exits, the pane
+// remains alive with its shell prompt. The resumer must therefore verify
+// agent ownership before injecting, and revival can reuse a surviving pane
+// only when Task 3 wires that path deliberately.
+
+import { execFile as execFileCb, spawn, spawnSync } from 'node:child_process';
+import { constants as osConstants } from 'node:os';
 import { basename } from 'node:path';
 import { promisify } from 'node:util';
 
-import { SessionCreateError } from './session-name.js';
+import { resolveSessionName, SessionCreateError } from './session-name.js';
 
 const execFileAsync = promisify(execFileCb);
 const MIN_VERSION = [0, 7, 5];
+const SERVER_POLL_MS = 50;
+const SERVER_POLL_ATTEMPTS = 80;
 
-function defaultSpawner(file, args, { sync = false, ...options } = {}) {
+function defaultSpawner(file, args, { sync = false, detach = false, ...options } = {}) {
+  if (detach) {
+    const child = spawn(file, args, {
+      ...options,
+      detached: true,
+      stdio: options.stdio ?? 'ignore',
+    });
+    child.unref();
+    return child;
+  }
   if (sync) return spawnSync(file, args, options);
   return execFileAsync(file, args, options).then(({ stdout }) => stdout);
 }
 
 function scrubHerdrEnv(env) {
   return Object.fromEntries(Object.entries(env).filter(([key]) => !key.startsWith('HERDR')));
+}
+
+function launchArgv({ file, args = [], env = {} }) {
+  const assignments = Object.entries(env)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `${key}=${value}`);
+  return ['/usr/bin/env', ...assignments, file, ...args];
+}
+
+function exitStatus(result) {
+  if (result.status !== null && result.status !== undefined) return result.status;
+  return result.signal ? 128 + (osConstants.signals[result.signal] || 0) : 1;
+}
+
+function wrappedSessionName(env) {
+  return env.UNSNOOZE_SESSION_NAME || env.UNSNOOZE_TMUX_SESSION || 'unsnooze';
 }
 
 function parseResult(stdout) {
@@ -54,6 +87,18 @@ export function createHerdr({ spawner = defaultSpawner, env = process.env } = {}
   const childEnv = () => scrubHerdrEnv(env);
   const run = (args, options = {}) => spawner('herdr', args, { env: childEnv(), ...options });
 
+  const parseSessionList = stdout => {
+    const result = parseResult(stdout);
+    return Array.isArray(result?.sessions) ? result.sessions : [];
+  };
+
+  const syncOutput = result => typeof result === 'string' ? result : (result?.stdout ?? '');
+
+  const sleepSync = milliseconds => {
+    const buffer = new Int32Array(new SharedArrayBuffer(4));
+    Atomics.wait(buffer, 0, 0, milliseconds);
+  };
+
   const build = owner => {
     const owned = (...args) => {
       if (!owner) throw new Error('unsnooze: herdr pane operation requires a session owner');
@@ -64,10 +109,125 @@ export function createHerdr({ spawner = defaultSpawner, env = process.env } = {}
       return run(['--session', session, ...args]);
     };
 
+    const sessionRunning = async name =>
+      (await backend.listSessions()).some(row => row.name === name && !row.exited);
+
+    const ensureSessionRunning = async name => {
+      if (await sessionRunning(name)) return;
+      let child;
+      try {
+        child = spawner('herdr', ['--session', name, 'server'], {
+          detach: true,
+          detached: true,
+          stdio: 'ignore',
+          env: childEnv(),
+        });
+      } catch (error) {
+        throw new SessionCreateError(
+          `failed to start herdr session "${name}": ${error.message}`, error,
+        );
+      }
+      if (child?.error) {
+        throw new SessionCreateError(
+          `failed to start herdr session "${name}": ${child.error.message}`, child.error,
+        );
+      }
+      for (let attempt = 0; attempt < SERVER_POLL_ATTEMPTS; attempt += 1) {
+        await new Promise(resolve => setTimeout(resolve, SERVER_POLL_MS));
+        if (await sessionRunning(name)) return;
+      }
+      throw new SessionCreateError(`herdr session "${name}" server did not start`);
+    };
+
+    const liveSessionNames = () => {
+      try {
+        const result = spawner('herdr', ['session', 'list', '--json'], {
+          sync: true,
+          encoding: 'utf8',
+          env: childEnv(),
+        });
+        return new Set(parseSessionList(syncOutput(result))
+          .filter(row => row?.running !== false && typeof row?.name === 'string')
+          .map(row => row.name));
+      } catch {
+        return new Set();
+      }
+    };
+
+    const sessionRunningSync = name => {
+      try {
+        const result = spawner('herdr', ['session', 'list', '--json'], {
+          sync: true,
+          encoding: 'utf8',
+          env: childEnv(),
+        });
+        return parseSessionList(syncOutput(result))
+          .some(row => row.name === name && row.running !== false);
+      } catch {
+        return false;
+      }
+    };
+
+    const ensureSessionRunningSync = name => {
+      if (sessionRunningSync(name)) return;
+      let child;
+      try {
+        child = spawner('herdr', ['--session', name, 'server'], {
+          detach: true,
+          detached: true,
+          stdio: 'ignore',
+          env: childEnv(),
+        });
+      } catch (error) {
+        throw new SessionCreateError(
+          `failed to start herdr session "${name}": ${error.message}`, error,
+        );
+      }
+      if (child?.error) {
+        throw new SessionCreateError(
+          `failed to start herdr session "${name}": ${child.error.message}`, child.error,
+        );
+      }
+      for (let attempt = 0; attempt < SERVER_POLL_ATTEMPTS; attempt += 1) {
+        sleepSync(SERVER_POLL_MS);
+        if (sessionRunningSync(name)) return;
+      }
+      throw new SessionCreateError(`herdr session "${name}" server did not start`);
+    };
+
+    const syncCall = (args, name, operation) => {
+      let result;
+      try {
+        result = spawner('herdr', args, {
+          sync: true,
+          encoding: 'utf8',
+          env: childEnv(),
+        });
+      } catch (error) {
+        throw new SessionCreateError(
+          `failed to ${operation} herdr session "${name}": ${error.message}`, error,
+        );
+      }
+      if (result?.error) {
+        throw new SessionCreateError(
+          `failed to ${operation} herdr session "${name}": ${result.error.message}`, result.error,
+        );
+      }
+      if (result?.status !== null && result?.status !== undefined && result.status !== 0) {
+        const stderr = result.stderr ? `: ${String(result.stderr).trim()}` : '';
+        throw new SessionCreateError(
+          `failed to ${operation} herdr session "${name}"${stderr}`,
+        );
+      }
+      return syncOutput(result);
+    };
+
     const backend = {
       name: 'herdr',
       owner,
       SUBMIT_DELAY_MS,
+
+      ensureSessionRunning,
 
       available() {
         try {
@@ -193,6 +353,50 @@ export function createHerdr({ spawner = defaultSpawner, env = process.env } = {}
         await run(['session', 'delete', name]);
       },
 
+      async newWindow(sessionName, cwd, launchSpec) {
+        await ensureSessionRunning(sessionName);
+        const workspace = parseResult(await inSession(
+          sessionName, 'workspace', 'create', '--cwd', cwd, '--label', 'unsnooze',
+        ));
+        const pane = workspace?.root_pane?.pane_id;
+        if (!pane) throw new Error('unsnooze: unexpected herdr workspace shape: no root_pane');
+        await inSession(sessionName, 'pane', 'run', String(pane), ...launchArgv(launchSpec));
+        return { pane: String(pane), paneOwner: sessionName };
+      },
+
+      launchWrapped(launchSpec) {
+        const live = liveSessionNames();
+        const name = resolveSessionName(wrappedSessionName(env), candidate => live.has(candidate));
+        try {
+          ensureSessionRunningSync(name);
+          const workspace = parseResult(syncCall([
+            '--session', name, 'workspace', 'create', '--cwd', process.cwd(), '--label', 'unsnooze',
+          ], name, 'create workspace'));
+          const pane = workspace?.root_pane?.pane_id;
+          if (!pane) throw new Error('unsnooze: unexpected herdr workspace shape: no root_pane');
+          syncCall([
+            '--session', name, 'pane', 'run', String(pane), ...launchArgv(launchSpec),
+          ], name, 'run pane');
+        } catch (error) {
+          if (error instanceof SessionCreateError) throw error;
+          throw new SessionCreateError(
+            `failed to start herdr session "${name}": ${error.message}`, error,
+          );
+        }
+
+        const result = spawner('herdr', ['session', 'attach', name], {
+          sync: true,
+          stdio: 'inherit',
+          env: childEnv(),
+        });
+        if (result?.error) {
+          throw new SessionCreateError(
+            `failed to attach herdr session "${name}": ${result.error.message}`, result.error,
+          );
+        }
+        return exitStatus(result);
+      },
+
       bind(nextOwner) {
         return build(nextOwner);
       },
@@ -209,5 +413,6 @@ const herdr = createHerdr();
 export const available = (...args) => herdr.available(...args);
 export const inside = (...args) => herdr.inside(...args);
 export const currentPaneId = (...args) => herdr.currentPaneId(...args);
+export const launchWrapped = (...args) => herdr.launchWrapped(...args);
 
 export default herdr;

--- a/src/notify.js
+++ b/src/notify.js
@@ -63,7 +63,8 @@ export function nativeNotify(title, message, {
   spawner = defaultSpawner,
 } = {}) {
   const mux = process.env.UNSNOOZE_MUX
-    || (process.env.ZELLIJ ? 'zellij' : (process.env.TMUX ? 'tmux' : null));
+    || (process.env.HERDR_ENV ? 'herdr'
+      : (process.env.ZELLIJ ? 'zellij' : (process.env.TMUX ? 'tmux' : null)));
   if (platform === 'darwin') {
     spawner('osascript', ['-e',
       `display notification ${appleScriptString(message)} with title ${appleScriptString(title)}`]);

--- a/src/prompt-queue.js
+++ b/src/prompt-queue.js
@@ -249,9 +249,9 @@ function selfCommand() {
 function dispatchEnv(entry, leaseId, mux, target) {
   const env = { UNSNOOZE_MUX: mux.name, UNSNOOZE_LEASE_ID: leaseId, UNSNOOZE_CWD: entry.cwd };
   // tmux pane ids are server-global — paneOwner is always null there. Only
-  // zellij needs UNSNOOZE_PANE_OWNER so bind() can address the right session
+  // zellij and herdr need UNSNOOZE_PANE_OWNER so bind() can address the right session
   // (same reasoning as resumer.js's reopenEnv).
-  if (mux.name === 'zellij') env.UNSNOOZE_PANE_OWNER = target;
+  if (mux.name === 'zellij' || mux.name === 'herdr') env.UNSNOOZE_PANE_OWNER = target;
   return env;
 }
 

--- a/src/reap.js
+++ b/src/reap.js
@@ -13,6 +13,7 @@ const log = makeLogger('reap');
 // How a user reaches a revived session. Shared by status, toast, and `sessions`.
 export function attachHint(muxName, sessionName) {
   if (!sessionName) return null;
+  if (muxName === 'herdr') return `herdr session attach ${sessionName}`;
   if (muxName === 'zellij') return `zellij attach ${sessionName}`;
   return `tmux attach -t ${sessionName}`;
 }
@@ -30,7 +31,7 @@ export function isUnsnoozeSessionName(name, base = MUX_SESSION_NAME) {
 }
 
 export async function listOwnedSessions({ muxName = null } = {}) {
-  const names = muxName ? [muxName] : ['tmux', 'zellij'];
+  const names = muxName ? [muxName] : ['tmux', 'zellij', 'herdr'];
   const out = [];
   for (const name of names) {
     let mux;
@@ -150,7 +151,7 @@ export async function reap({
   }
 
   // Empty / EXITED unsnooze-owned sessions.
-  for (const name of ['tmux', 'zellij']) {
+  for (const name of ['tmux', 'zellij', 'herdr']) {
     let mux;
     try { mux = getMultiplexer(name); } catch { continue; }
     if (!mux.available?.() || typeof mux.listSessions !== 'function') continue;
@@ -167,7 +168,8 @@ export async function reap({
       } catch { panes = []; }
       const empty = panes.length === 0;
       const exited = !!row.exited;
-      // tmux auto-destroys empty sessions; only act when empty (or EXITED for zellij).
+      // tmux auto-destroys empty sessions; only act when empty (or EXITED for
+      // backends that retain an exited session, including zellij and herdr).
       if (!empty && !exited) continue;
       actions.push({
         kind: 'delete-session',

--- a/src/report.js
+++ b/src/report.js
@@ -26,8 +26,10 @@ export function buildIssueUrl(agentId, captureText) {
 export async function cmdReport(rest) {
   const [agentId = 'grok', paneArg] = rest;
   const selected = getMultiplexer();
-  let paneOwner = selected.name === 'zellij'
-    ? (process.env.UNSNOOZE_PANE_OWNER || process.env.ZELLIJ_SESSION_NAME || null) : null;
+  let paneOwner = selected.name === 'herdr'
+    ? (process.env.UNSNOOZE_PANE_OWNER || process.env.HERDR_SESSION || 'default')
+    : selected.name === 'zellij'
+      ? (process.env.UNSNOOZE_PANE_OWNER || process.env.ZELLIJ_SESSION_NAME || null) : null;
   let pane = paneArg || selected.currentPaneId();
   if (paneArg && selected.name === 'zellij' && paneArg.includes(':')) {
     [paneOwner, pane] = paneArg.split(/:(.*)/s, 2);

--- a/src/resumer.js
+++ b/src/resumer.js
@@ -142,8 +142,8 @@ function reopenEnv(rec, leaseId, target) {
   const env = { ...(rec.env || {}) };
   env.UNSNOOZE_MUX = rec.mux;
   // tmux pane ids are server-global — paneOwner is always null there. Only
-  // zellij needs UNSNOOZE_PANE_OWNER so bind() can address the right session.
-  if (rec.mux === 'zellij') {
+  // zellij and herdr need UNSNOOZE_PANE_OWNER so bind() can address the right session.
+  if (rec.mux === 'zellij' || rec.mux === 'herdr') {
     env.UNSNOOZE_PANE_OWNER = target || rec.paneOwner || rec.muxSession || '';
   }
   env.UNSNOOZE_LEASE_ID = leaseId;

--- a/src/settings.js
+++ b/src/settings.js
@@ -13,7 +13,7 @@ import { STATE_DIR } from './config.js';
 export const CONFIG_FILE = () => join(process.env.UNSNOOZE_STATE_DIR || STATE_DIR, 'config.json');
 
 export const DEFAULTS = {
-  multiplexer: 'auto',    // auto | tmux | zellij
+  multiplexer: 'auto',    // auto | tmux | zellij | herdr
   autoResume: true,        // master switch: dispatch resumes when limits reset
   menuAutoAnswer: true,    // may unsnooze drive Claude's limit menu (send keys)?
   notifications: true,     // desktop notifications on detect/resume
@@ -92,7 +92,7 @@ const KNOWN_KEYS = Object.keys(ENV_NAMES);
 
 // String settings restricted to a fixed set of values.
 const ENUMS = {
-  multiplexer: ['auto', 'tmux', 'zellij'],
+  multiplexer: ['auto', 'tmux', 'zellij', 'herdr'],
   workspaceGuard: ['off', 'inform', 'pause'],
   contextGuard: ['off', 'inform', 'pause'],
   notifyChannel: ['auto', 'native', 'osc', 'bell'],

--- a/test/fleet.test.js
+++ b/test/fleet.test.js
@@ -273,6 +273,7 @@ test('attachHintRemote wraps the local hint in ssh -t', async () => {
   const { attachHintRemote } = await import('../src/fleet.js');
   assert.equal(attachHintRemote('gpu', 'tmux', 'unsnooze'), `ssh -t gpu 'tmux new -A -s unsnooze'`);
   assert.equal(attachHintRemote('gpu', 'zellij', 'unsnooze'), `ssh -t gpu 'zellij attach unsnooze'`);
+  assert.equal(attachHintRemote('gpu', 'herdr', 'unsnooze'), `ssh -t gpu 'herdr session attach unsnooze'`);
 });
 
 test('attachHintRemote: hostile muxSession (shell metachars) yields no hint at all', async () => {

--- a/test/herdr-wiring.test.js
+++ b/test/herdr-wiring.test.js
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { hookContext } from '../src/hook.js';
+import { resolvePaneOwner } from '../src/launcher.js';
+
+test('hook derives a managed herdr address from unsnooze context', () => {
+  assert.deepEqual(hookContext({
+    UNSNOOZE_MUX: 'herdr',
+    UNSNOOZE_PANE: 'w2:p4',
+    UNSNOOZE_PANE_OWNER: 'managed-session',
+    HERDR_PANE_ID: 'ambient-pane',
+    HERDR_SESSION: 'ambient-session',
+    ZELLIJ_PANE_ID: 'wrong-pane',
+  }, {}), {
+    muxName: 'herdr', pane: 'w2:p4', paneOwner: 'managed-session',
+  });
+});
+
+test('hook derives an unmanaged herdr address and defaults owner to default', () => {
+  assert.deepEqual(hookContext({
+    HERDR_PANE_ID: 'w1:p1',
+    ZELLIJ_PANE_ID: 'wrong-pane',
+  }, {}), {
+    muxName: 'herdr', pane: 'w1:p1', paneOwner: 'default',
+  });
+  assert.equal(hookContext({ HERDR_PANE_ID: 'w1:p1', HERDR_SESSION: 'named' }, {}).paneOwner, 'named');
+});
+
+test('launcher resolves herdr pane owner from managed or ambient session', () => {
+  assert.equal(resolvePaneOwner('herdr', {
+    UNSNOOZE_MUX: 'herdr', UNSNOOZE_PANE_OWNER: 'managed', HERDR_SESSION: 'ambient',
+  }), 'managed');
+  assert.equal(resolvePaneOwner('herdr', { HERDR_SESSION: 'ambient' }), 'ambient');
+  assert.equal(resolvePaneOwner('herdr', {}), 'default');
+  assert.equal(resolvePaneOwner('tmux', { HERDR_SESSION: 'ambient' }), null);
+});

--- a/test/multiplexer-herdr.test.js
+++ b/test/multiplexer-herdr.test.js
@@ -306,3 +306,208 @@ test('herdr does not expose tmux-only tty or ownership methods', () => {
     assert.equal(typeof mux[method], 'undefined', method);
   }
 });
+
+const noNamedSession = JSON.stringify({
+  sessions: [{ default: true, name: 'default', running: true }],
+});
+
+const runningNamedSession = JSON.stringify({
+  sessions: [
+    { default: true, name: 'default', running: true },
+    { default: false, name: 'revival', running: true,
+      session_dir: '/home/ubuntu/.config/herdr/sessions/revival',
+      socket_path: '/home/ubuntu/.config/herdr/sessions/revival/herdr.sock' },
+  ],
+});
+
+test('ensureSessionRunning starts a detached server and polls until running', async () => {
+  let listCalls = 0;
+  const spawner = fakeSpawner((_file, args, options) => {
+    if (args.join(' ') === 'session list --json') {
+      listCalls += 1;
+      return listCalls === 1 ? noNamedSession : runningNamedSession;
+    }
+    if (options.detach) return { pid: 1234, unref() {} };
+    throw new Error(`unexpected call: ${args.join(' ')}`);
+  });
+  const mux = createHerdr({ spawner, env: {} });
+
+  await mux.ensureSessionRunning('revival');
+  assert.equal(listCalls, 2);
+  assert.deepEqual(spawner.calls[1].args, ['--session', 'revival', 'server']);
+  assert.equal(spawner.calls[1].options.detach, true);
+  assert.equal(spawner.calls[1].options.detached, true);
+  assert.equal(spawner.calls[1].options.stdio, 'ignore');
+});
+
+test('ensureSessionRunning does nothing when the named server is already running', async () => {
+  const spawner = fakeSpawner((_file, args) => {
+    if (args.join(' ') === 'session list --json') return runningNamedSession;
+    throw new Error(`unexpected call: ${args.join(' ')}`);
+  });
+  await createHerdr({ spawner, env: {} }).ensureSessionRunning('revival');
+  assert.equal(spawner.calls.length, 1);
+});
+
+test('ensureSessionRunning raises SessionCreateError when the server never becomes ready', async () => {
+  const spawner = fakeSpawner((_file, args, options) => {
+    if (args.join(' ') === 'session list --json') return noNamedSession;
+    if (options.detach) return { pid: 1234, unref() {} };
+    throw new Error(`unexpected call: ${args.join(' ')}`);
+  });
+  await assert.rejects(
+    () => createHerdr({ spawner, env: {} }).ensureSessionRunning('never'),
+    err => err.name === 'SessionCreateError' && /never.*server did not start/.test(err.message),
+  );
+});
+
+test('newWindow ensures the session, creates a workspace, then runs raw argv without --', async () => {
+  const spawner = fakeSpawner((_file, args, options) => {
+    if (args.join(' ') === 'session list --json') return runningNamedSession;
+    if (args.includes('workspace') && args.includes('create')) return workspaceCreated;
+    if (args.includes('pane') && args.includes('run')) return '';
+    if (options.detach) return { pid: 1234, unref() {} };
+    throw new Error(`unexpected call: ${args.join(' ')}`);
+  });
+  const mux = createHerdr({ spawner, env: {} });
+  const launchSpec = {
+    file: '/usr/bin/node', args: ['agent.js', '--resume', 'abc'],
+    env: { LEASE: 'xyz', EMPTY: '', OMIT: undefined },
+  };
+
+  assert.deepEqual(await mux.newWindow('revival', '/tmp/project', launchSpec), {
+    pane: 'w1:p1', paneOwner: 'revival',
+  });
+  const run = spawner.calls.find(call => call.args.includes('run'));
+  assert.deepEqual(run.args, [
+    '--session', 'revival', 'pane', 'run', 'w1:p1',
+    '/usr/bin/env', 'LEASE=xyz', 'EMPTY=', '/usr/bin/node', 'agent.js', '--resume', 'abc',
+  ]);
+  assert.equal(run.args.includes('--'), false);
+});
+
+test('newWindow throws when workspace create has no root pane id', async () => {
+  const spawner = fakeSpawner((_file, args) => {
+    if (args.join(' ') === 'session list --json') return runningNamedSession;
+    if (args.includes('workspace') && args.includes('create')) {
+      return JSON.stringify({ id: 'cli:workspace:create', result: { type: 'workspace_created' } });
+    }
+    throw new Error(`unexpected call: ${args.join(' ')}`);
+  });
+  await assert.rejects(
+    () => createHerdr({ spawner, env: {} }).newWindow('revival', '/tmp', {
+      file: 'node', args: [], env: {},
+    }),
+    /unexpected herdr workspace shape: no root_pane/,
+  );
+});
+
+function syncLaunchSpawner({ sessions, attachResult = { status: 0 }, onCall = () => {} }) {
+  return fakeSpawner((_file, args, options) => {
+    onCall(args, options);
+    if (args.join(' ') === 'session list --json') {
+      const stdout = typeof sessions === 'function' ? sessions() : sessions;
+      return { status: 0, stdout };
+    }
+    if (options.detach) return { pid: 1234, unref() {} };
+    if (args.includes('workspace') && args.includes('create')) {
+      return { status: 0, stdout: workspaceCreated };
+    }
+    if (args.includes('pane') && args.includes('run')) return { status: 0, stdout: '' };
+    if (args[0] === 'session' && args[1] === 'attach') return attachResult;
+    throw new Error(`unexpected call: ${args.join(' ')}`);
+  });
+}
+
+test('launchWrapped sidesteps a taken session name and attaches synchronously', () => {
+  let listCalls = 0;
+  const spawner = syncLaunchSpawner({
+    sessions: () => {
+      listCalls += 1;
+      if (listCalls <= 2) return JSON.stringify({ sessions: [
+        { default: true, name: 'default', running: true },
+        { default: false, name: 'unsnooze', running: true },
+      ] });
+      return JSON.stringify({ sessions: [
+        { default: true, name: 'default', running: true },
+        { default: false, name: 'unsnooze', running: true },
+        { default: false, name: 'unsnooze-2', running: true },
+      ] });
+    },
+  });
+  const mux = createHerdr({ spawner, env: { UNSNOOZE_SESSION_NAME: 'unsnooze' } });
+
+  assert.equal(mux.launchWrapped({ file: 'node', args: ['agent.js'], env: { FOO: 'bar' } }), 0);
+  const attach = spawner.calls.find(call => call.args[0] === 'session' && call.args[1] === 'attach');
+  assert.deepEqual(attach.args, ['session', 'attach', 'unsnooze-2']);
+  assert.equal(attach.options.sync, true);
+  assert.equal(attach.options.stdio, 'inherit');
+  assert.equal(spawner.calls.some(call => call.options.detach), true);
+});
+
+test('launchWrapped throws SessionCreateError when attach reports a spawn error', () => {
+  let listCalls = 0;
+  const cause = new Error('herdr unavailable');
+  const spawner = syncLaunchSpawner({
+    sessions: () => {
+      listCalls += 1;
+      return listCalls === 1 ? runningNamedSession : JSON.stringify({ sessions: [
+        { default: true, name: 'default', running: true },
+        { default: false, name: 'revival', running: true },
+        { default: false, name: 'revival-2', running: true },
+      ] });
+    },
+    attachResult: { error: cause },
+  });
+  const mux = createHerdr({ spawner, env: { UNSNOOZE_SESSION_NAME: 'revival' } });
+  assert.throws(
+    () => mux.launchWrapped({ file: 'node', args: [], env: {} }),
+    err => err.name === 'SessionCreateError' && err.cause === cause && /revival/.test(err.message),
+  );
+});
+
+test('launchWrapped maps a Ctrl-C attach signal to exit status 130', () => {
+  let listCalls = 0;
+  const spawner = syncLaunchSpawner({
+    sessions: () => {
+      listCalls += 1;
+      return listCalls === 1 ? runningNamedSession : JSON.stringify({ sessions: [
+        { default: true, name: 'default', running: true },
+        { default: false, name: 'revival', running: true },
+        { default: false, name: 'revival-2', running: true },
+      ] });
+    },
+    attachResult: { status: null, signal: 'SIGINT' },
+  });
+  const mux = createHerdr({ spawner, env: { UNSNOOZE_SESSION_NAME: 'revival' } });
+  assert.equal(mux.launchWrapped({ file: 'node', args: [], env: {} }), 130);
+});
+
+test('launchWrapped raises SessionCreateError when headless server startup times out', () => {
+  const spawner = syncLaunchSpawner({
+    sessions: noNamedSession,
+  });
+  const mux = createHerdr({ spawner, env: { UNSNOOZE_SESSION_NAME: 'never' } });
+  assert.throws(
+    () => mux.launchWrapped({ file: 'node', args: [], env: {} }),
+    err => err.name === 'SessionCreateError' && /never.*server did not start/.test(err.message),
+  );
+});
+
+test('launchWrapped does not inject the wrapped session name into pane argv env', () => {
+  let listCalls = 0;
+  const spawner = syncLaunchSpawner({
+    sessions: () => {
+      listCalls += 1;
+      return listCalls === 1 ? runningNamedSession : JSON.stringify({ sessions: [
+        { default: true, name: 'default', running: true },
+        { default: false, name: 'revival', running: true },
+        { default: false, name: 'revival-2', running: true },
+      ] });
+    },
+  });
+  const mux = createHerdr({ spawner, env: { UNSNOOZE_SESSION_NAME: 'revival' } });
+  mux.launchWrapped({ file: 'node', args: [], env: { PATH: '/bin' } });
+  const run = spawner.calls.find(call => call.args.includes('run'));
+  assert.equal(run.args.includes('UNSNOOZE_SESSION_NAME=revival'), false);
+});

--- a/test/multiplexer-herdr.test.js
+++ b/test/multiplexer-herdr.test.js
@@ -1,0 +1,308 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createHerdr, SUBMIT_DELAY_MS } from '../src/multiplexers/herdr.js';
+
+function fakeSpawner(respond = () => '') {
+  const calls = [];
+  const spawner = (file, args, options = {}) => {
+    calls.push({ file, args, options });
+    return respond(file, args, options);
+  };
+  spawner.calls = calls;
+  return spawner;
+}
+
+const workspaceCreated = JSON.stringify({
+  id: 'cli:workspace:create',
+  result: {
+    root_pane: {
+      agent_status: 'unknown', cwd: '/tmp', focused: false,
+      foreground_cwd: '/tmp', pane_id: 'w1:p1', revision: 0,
+      scroll: { max_offset_from_bottom: 0, offset_from_bottom: 0, viewport_rows: 53 },
+      tab_id: 'w1:t1', terminal_id: 'term_probe', workspace_id: 'w1',
+    },
+    tab: { agent_status: 'unknown', focused: false, label: '1', number: 1,
+      pane_count: 1, tab_id: 'w1:t1', workspace_id: 'w1' },
+    type: 'workspace_created',
+    workspace: { active_tab_id: 'w1:t1', agent_status: 'unknown', focused: false,
+      label: 'probe', number: 1, pane_count: 1, tab_count: 1, workspace_id: 'w1' },
+  },
+});
+
+const paneInfo = JSON.stringify({
+  id: 'cli:pane:get',
+  result: {
+    pane: {
+      agent_status: 'unknown', cwd: '/tmp', focused: false,
+      foreground_cwd: '/tmp', pane_id: 'w1:p1', revision: 0,
+      scroll: { max_offset_from_bottom: 0, offset_from_bottom: 0, viewport_rows: 53 },
+      tab_id: 'w1:t1', terminal_id: 'term_probe', workspace_id: 'w1',
+    },
+    type: 'pane_info',
+  },
+});
+
+const paneNotFound = JSON.stringify({
+  error: { code: 'pane_not_found', message: 'pane w1:p1 not found' },
+  id: 'cli:pane:get',
+});
+
+const processInfo = JSON.stringify({
+  id: 'cli:pane:process-info',
+  result: {
+    process_info: {
+      foreground_processes: [
+        { argv: ['/usr/bin/node', 'agent.js'], cmdline: '/usr/bin/node agent.js',
+          name: 'node', pid: 101, cwd: '/tmp' },
+        { argv: ['/usr/bin/npm', 'exec', '@upstash/cli'], cmdline: 'npm exec @upstash/cli',
+          name: 'npm exec @upsta', pid: 202, cwd: '/tmp' },
+      ],
+      foreground_process_group_id: 202,
+      shell_pid: 99,
+    },
+    type: 'pane_process_info',
+  },
+});
+
+const processInfoFallback = JSON.stringify({
+  id: 'cli:pane:process-info',
+  result: {
+    process_info: {
+      foreground_processes: [
+        { argv: ['/opt/bin/claude', '--resume', 'abc'], cmdline: 'claude --resume abc',
+          name: 'claude', pid: 303, cwd: '/tmp' },
+      ],
+      foreground_process_group_id: 999,
+      shell_pid: 99,
+    },
+    type: 'pane_process_info',
+  },
+});
+
+const paneList = JSON.stringify({
+  id: 'cli:pane:list',
+  result: {
+    panes: [
+      { pane_id: 'w1:p1', workspace_id: 'w1', tab_id: 'w1:t1', cwd: '/tmp',
+        agent: 'claude', agent_status: 'working', terminal_title: 'agent' },
+      { pane_id: 'w1:p2', workspace_id: 'w1', tab_id: 'w1:t1', cwd: '/tmp',
+        agent_status: 'unknown', terminal_title: '' },
+    ],
+    type: 'pane_list',
+  },
+});
+
+const sessionList = JSON.stringify({
+  sessions: [
+    { default: true, name: 'default', running: true,
+      session_dir: '/home/ubuntu/.config/herdr', socket_path: '/home/ubuntu/.config/herdr/herdr.sock' },
+    { default: false, name: 'stopped', running: false,
+      session_dir: '/home/ubuntu/.config/herdr/sessions/stopped', socket_path: '/tmp/stopped.sock' },
+  ],
+});
+
+test('available enforces the herdr 0.7.5 version floor and handles failures', () => {
+  const versions = [
+    ['herdr 0.7.5\n', true],
+    ['herdr 0.7.6\n', true],
+    ['herdr 1.0.0\n', true],
+    ['herdr 0.7.4\n', false],
+    ['herdr 0.6.0\n', false],
+  ];
+  for (const [stdout, expected] of versions) {
+    const mux = createHerdr({
+      spawner: fakeSpawner(() => ({ status: 0, stdout })), env: {},
+    });
+    assert.equal(mux.available(), expected, stdout);
+  }
+  assert.equal(createHerdr({
+    spawner: fakeSpawner(() => ({ status: 1, stdout: 'herdr 0.7.5\n' })), env: {},
+  }).available(), false);
+  assert.equal(createHerdr({
+    spawner: fakeSpawner(() => { throw new Error('not installed'); }), env: {},
+  }).available(), false);
+  assert.equal(createHerdr({
+    spawner: fakeSpawner(() => ({ status: 0, stdout: 'not a version' })), env: {},
+  }).available(), false);
+});
+
+test('inside and currentPaneId honor herdr identity without cross-backend bleed', () => {
+  const ambient = {
+    HERDR_ENV: '1', HERDR_PANE_ID: 'w1:p1', HERDR_SESSION: 'ambient',
+    UNSNOOZE_MUX: 'herdr', UNSNOOZE_PANE: 'managed',
+  };
+  const mux = createHerdr({ spawner: fakeSpawner(), env: ambient });
+  assert.equal(mux.inside(), true);
+  assert.equal(mux.currentPaneId(), 'managed');
+
+  assert.equal(createHerdr({ spawner: fakeSpawner(), env: {
+    HERDR_PANE_ID: 'ambient', UNSNOOZE_MUX: 'zellij', UNSNOOZE_PANE: 'wrong',
+  } }).currentPaneId(), 'ambient');
+  assert.equal(createHerdr({ spawner: fakeSpawner(), env: {
+    UNSNOOZE_MUX: 'herdr', UNSNOOZE_PANE: 'managed',
+  } }).currentPaneId(), 'managed');
+  assert.equal(createHerdr({ spawner: fakeSpawner(), env: {} }).inside(), false);
+  assert.equal(createHerdr({ spawner: fakeSpawner(), env: {} }).currentPaneId(), null);
+});
+
+test('owner-bound calls scrub inherited HERDR variables and pass explicit session', async () => {
+  const spawner = fakeSpawner(() => 'screen text');
+  const mux = createHerdr({
+    spawner,
+    env: { PATH: '/bin', KEEP: 'yes', HERDR_ENV: '1', HERDR_PANE_ID: 'bad',
+      HERDR_SOCKET_PATH: '/bad.sock', HERDR_SESSION: 'wrong' },
+  }).bind('OWNER');
+
+  assert.equal(await mux.capturePane('w1:p1', 5), 'screen text');
+  assert.deepEqual(spawner.calls[0].args,
+    ['--session', 'OWNER', 'pane', 'read', 'w1:p1', '--source', 'recent', '--lines', '5', '--format', 'text']);
+  assert.equal(spawner.calls[0].options.env.PATH, '/bin');
+  assert.equal(spawner.calls[0].options.env.KEEP, 'yes');
+  assert.equal(Object.keys(spawner.calls[0].options.env).some(key => key.startsWith('HERDR')), false);
+});
+
+test('capturePaneVisible uses raw visible text args', async () => {
+  const spawner = fakeSpawner(() => 'visible\n');
+  const mux = createHerdr({ spawner, env: {} }).bind('OWNER');
+  assert.equal(await mux.capturePaneVisible('w1:p1'), 'visible\n');
+  assert.deepEqual(spawner.calls[0].args,
+    ['--session', 'OWNER', 'pane', 'read', 'w1:p1', '--source', 'visible', '--format', 'text']);
+});
+
+test('sendText sends literal text and submits after the required delay', async () => {
+  const spawner = fakeSpawner(() => '');
+  const mux = createHerdr({ spawner, env: {} }).bind('OWNER');
+  const started = Date.now();
+  await mux.sendText('w1:p1', 'echo hi');
+  assert.ok(Date.now() - started >= SUBMIT_DELAY_MS - 10);
+  assert.deepEqual(spawner.calls.map(call => call.args), [
+    ['--session', 'OWNER', 'pane', 'send-text', 'w1:p1', 'echo hi'],
+    ['--session', 'OWNER', 'pane', 'send-keys', 'w1:p1', 'enter'],
+  ]);
+});
+
+test('sendKey maps named keys and falls back to literal text', async () => {
+  const spawner = fakeSpawner(() => '');
+  const mux = createHerdr({ spawner, env: {} }).bind('OWNER');
+  await mux.sendKey('w1:p1', 'Escape');
+  await mux.sendKey('w1:p1', 'ctrl+c');
+  assert.deepEqual(spawner.calls.map(call => call.args), [
+    ['--session', 'OWNER', 'pane', 'send-keys', 'w1:p1', 'esc'],
+    ['--session', 'OWNER', 'pane', 'send-text', 'w1:p1', 'ctrl+c'],
+  ]);
+});
+
+test('paneAlive accepts a matching pane and rejects pane_not_found or mismatched JSON', async () => {
+  let stdout = paneInfo;
+  const spawner = fakeSpawner(() => stdout);
+  const mux = createHerdr({ spawner, env: {} }).bind('OWNER');
+  assert.equal(await mux.paneAlive('w1:p1'), true);
+  stdout = paneNotFound;
+  assert.equal(await mux.paneAlive('w1:p1'), false);
+  stdout = JSON.stringify({ id: 'cli:pane:get', result: { pane: { pane_id: 'w1:p2' } } });
+  assert.equal(await mux.paneAlive('w1:p1'), false);
+  stdout = undefined;
+  const rejecting = createHerdr({ spawner: fakeSpawner(() => { throw new Error('missing'); }), env: {} }).bind('OWNER');
+  assert.equal(await rejecting.paneAlive('w1:p1'), false);
+});
+
+test('paneCurrentCommand selects the foreground process group and uses argv over truncated comm', async () => {
+  let stdout = processInfo;
+  const spawner = fakeSpawner(() => stdout);
+  const mux = createHerdr({ spawner, env: {} }).bind('OWNER');
+  assert.equal(await mux.paneCurrentCommand('w1:p1'), 'npm');
+  stdout = processInfoFallback;
+  assert.equal(await mux.paneCurrentCommand('w1:p1'), 'claude');
+  stdout = JSON.stringify({ id: 'cli:pane:process-info', result: { process_info: {
+    foreground_processes: [], foreground_process_group_id: 0, shell_pid: 99,
+  } } });
+  assert.equal(await mux.paneCurrentCommand('w1:p1'), null);
+  stdout = 'not json';
+  assert.equal(await mux.paneCurrentCommand('w1:p1'), null);
+});
+
+test('sessionForPane returns the expected ambient session identities', async () => {
+  assert.equal(await createHerdr({ spawner: fakeSpawner(), env: {
+    HERDR_ENV: '1', HERDR_SESSION: 'ambient',
+  } }).bind('owner').sessionForPane('w1:p1'), 'owner');
+  assert.equal(await createHerdr({ spawner: fakeSpawner(), env: {
+    HERDR_ENV: '1', HERDR_SESSION: 'ambient',
+  } }).sessionForPane('w1:p1'), 'ambient');
+  assert.equal(await createHerdr({ spawner: fakeSpawner(), env: {
+    HERDR_PANE_ID: 'w1:p1',
+  } }).sessionForPane('w1:p1'), 'default');
+  assert.equal(await createHerdr({ spawner: fakeSpawner(), env: {} }).sessionForPane('w1:p1'), null);
+});
+
+test('listSessions parses bare session JSON and sessionExists uses it', async () => {
+  const spawner = fakeSpawner(() => sessionList);
+  const mux = createHerdr({ spawner, env: {} });
+  assert.deepEqual(await mux.listSessions(), [
+    { name: 'default', exited: false },
+    { name: 'stopped', exited: true },
+  ]);
+  assert.equal(await mux.sessionExists('stopped'), true);
+  assert.equal(await mux.sessionExists('missing'), false);
+});
+
+test('listSessions returns an empty list on malformed or failed output', async () => {
+  assert.deepEqual(await createHerdr({
+    spawner: fakeSpawner(() => 'not json'), env: {},
+  }).listSessions(), []);
+  assert.deepEqual(await createHerdr({
+    spawner: fakeSpawner(() => { throw new Error('unreachable'); }), env: {},
+  }).listSessions(), []);
+});
+
+test('listSessionPanes parses pane ids under an explicit session override', async () => {
+  const spawner = fakeSpawner(() => paneList);
+  const mux = createHerdr({ spawner, env: {} });
+  assert.deepEqual(await mux.listSessionPanes('OWNER'), ['w1:p1', 'w1:p2']);
+  assert.deepEqual(spawner.calls[0].args, ['--session', 'OWNER', 'pane', 'list']);
+});
+
+test('listSessionPanes returns an empty list on malformed or failed output', async () => {
+  assert.deepEqual(await createHerdr({
+    spawner: fakeSpawner(() => 'not json'), env: {},
+  }).listSessionPanes('OWNER'), []);
+  assert.deepEqual(await createHerdr({
+    spawner: fakeSpawner(() => { throw new Error('unreachable'); }), env: {},
+  }).listSessionPanes('OWNER'), []);
+});
+
+test('closePane requires an owner and uses the owner-bound pane close command', async () => {
+  await assert.rejects(() => createHerdr({ spawner: fakeSpawner(), env: {} }).closePane('w1:p1'),
+    /requires a session owner/);
+  const spawner = fakeSpawner(() => JSON.stringify({ result: { type: 'ok' } }));
+  await createHerdr({ spawner, env: {} }).bind('OWNER').closePane('w1:p1');
+  assert.deepEqual(spawner.calls[0].args, ['--session', 'OWNER', 'pane', 'close', 'w1:p1']);
+});
+
+test('deleteSession stops best effort, then deletes the named session', async () => {
+  const spawner = fakeSpawner((_file, args) => {
+    if (args[1] === 'stop') throw new Error('already stopped');
+    return 'deleted session OWNER';
+  });
+  await createHerdr({ spawner, env: {} }).deleteSession('OWNER');
+  assert.deepEqual(spawner.calls.map(call => call.args), [
+    ['session', 'stop', 'OWNER'],
+    ['session', 'delete', 'OWNER'],
+  ]);
+});
+
+test('bind creates independent owner-bound backends', async () => {
+  const spawner = fakeSpawner(() => '');
+  const mux = createHerdr({ spawner, env: {} });
+  await mux.bind('one').capturePane('w1:p1');
+  await mux.bind('two').capturePane('w1:p1');
+  assert.equal(spawner.calls[0].args[1], 'one');
+  assert.equal(spawner.calls[1].args[1], 'two');
+});
+
+test('herdr does not expose tmux-only tty or ownership methods', () => {
+  const mux = createHerdr({ spawner: fakeSpawner(), env: {} });
+  for (const method of ['clientTtys', 'paneTty', 'globalEnv', 'stampPaneOwner', 'paneOwnerStamp']) {
+    assert.equal(typeof mux[method], 'undefined', method);
+  }
+});

--- a/test/multiplexer-herdr.test.js
+++ b/test/multiplexer-herdr.test.js
@@ -361,7 +361,7 @@ test('ensureSessionRunning raises SessionCreateError when the server never becom
   );
 });
 
-test('newWindow ensures the session, creates a workspace, then runs raw argv without --', async () => {
+test('newWindow puts whitelisted launch env on workspace and runs bare argv', async () => {
   const spawner = fakeSpawner((_file, args, options) => {
     if (args.join(' ') === 'session list --json') return runningNamedSession;
     if (args.includes('workspace') && args.includes('create')) return workspaceCreated;
@@ -372,16 +372,28 @@ test('newWindow ensures the session, creates a workspace, then runs raw argv wit
   const mux = createHerdr({ spawner, env: {} });
   const launchSpec = {
     file: '/usr/bin/node', args: ['agent.js', '--resume', 'abc'],
-    env: { LEASE: 'xyz', EMPTY: '', OMIT: undefined },
+    env: {
+      UNSNOOZE_MUX: 'herdr',
+      UNSNOOZE_PANE_OWNER: 'revival',
+      UNSNOOZE_MESSAGE: 'hello world "quoted"',
+      LEASE: 'xyz', EMPTY: '', OMIT: undefined,
+    },
   };
 
   assert.deepEqual(await mux.newWindow('revival', '/tmp/project', launchSpec), {
     pane: 'w1:p1', paneOwner: 'revival',
   });
+  const workspace = spawner.calls.find(call => call.args.includes('workspace'));
+  assert.deepEqual(workspace.args, [
+    '--session', 'revival', 'workspace', 'create', '--cwd', '/tmp/project', '--label', 'unsnooze',
+    '--env', 'UNSNOOZE_MUX=herdr',
+    '--env', 'UNSNOOZE_PANE_OWNER=revival',
+    '--env', 'UNSNOOZE_MESSAGE=hello world "quoted"',
+  ]);
   const run = spawner.calls.find(call => call.args.includes('run'));
   assert.deepEqual(run.args, [
     '--session', 'revival', 'pane', 'run', 'w1:p1',
-    '/usr/bin/env', 'LEASE=xyz', 'EMPTY=', '/usr/bin/node', 'agent.js', '--resume', 'abc',
+    '/usr/bin/node', 'agent.js', '--resume', 'abc',
   ]);
   assert.equal(run.args.includes('--'), false);
 });
@@ -437,7 +449,20 @@ test('launchWrapped sidesteps a taken session name and attaches synchronously', 
   });
   const mux = createHerdr({ spawner, env: { UNSNOOZE_SESSION_NAME: 'unsnooze' } });
 
-  assert.equal(mux.launchWrapped({ file: 'node', args: ['agent.js'], env: { FOO: 'bar' } }), 0);
+  assert.equal(mux.launchWrapped({
+    file: 'node', args: ['agent.js'],
+    env: { UNSNOOZE_LEASE_ID: 'lease with spaces', UNSNOOZE_SESSION_NAME: 'revival', FOO: 'bar' },
+  }), 0);
+  const workspace = spawner.calls.find(call => call.args.includes('workspace'));
+  assert.deepEqual(workspace.args, [
+    '--session', 'unsnooze-2', 'workspace', 'create', '--cwd', process.cwd(), '--label', 'unsnooze',
+    '--env', 'UNSNOOZE_LEASE_ID=lease with spaces',
+    '--env', 'UNSNOOZE_SESSION_NAME=revival',
+  ]);
+  const run = spawner.calls.find(call => call.args.includes('run'));
+  assert.deepEqual(run.args, [
+    '--session', 'unsnooze-2', 'pane', 'run', 'w1:p1', 'node', 'agent.js',
+  ]);
   const attach = spawner.calls.find(call => call.args[0] === 'session' && call.args[1] === 'attach');
   assert.deepEqual(attach.args, ['session', 'attach', 'unsnooze-2']);
   assert.equal(attach.options.sync, true);
@@ -494,7 +519,7 @@ test('launchWrapped raises SessionCreateError when headless server startup times
   );
 });
 
-test('launchWrapped does not inject the wrapped session name into pane argv env', () => {
+test('launchWrapped does not encode non-UNSNOOZE env in pane argv', () => {
   let listCalls = 0;
   const spawner = syncLaunchSpawner({
     sessions: () => {
@@ -507,7 +532,12 @@ test('launchWrapped does not inject the wrapped session name into pane argv env'
     },
   });
   const mux = createHerdr({ spawner, env: { UNSNOOZE_SESSION_NAME: 'revival' } });
-  mux.launchWrapped({ file: 'node', args: [], env: { PATH: '/bin' } });
+  mux.launchWrapped({ file: 'node', args: [], env: { PATH: '/bin', UNSNOOZE_SESSION_NAME: 'revival' } });
+  const workspace = spawner.calls.find(call => call.args.includes('workspace'));
+  assert.deepEqual(workspace.args.slice(-2), ['--env', 'UNSNOOZE_SESSION_NAME=revival']);
   const run = spawner.calls.find(call => call.args.includes('run'));
+  assert.deepEqual(run.args.slice(-1), ['node']);
+  assert.equal(run.args.includes('/usr/bin/env'), false);
+  assert.equal(run.args.includes('PATH=/bin'), false);
   assert.equal(run.args.includes('UNSNOOZE_SESSION_NAME=revival'), false);
 });

--- a/test/multiplexer.test.js
+++ b/test/multiplexer.test.js
@@ -40,28 +40,47 @@ function fakeBackend(name, { installed = true } = {}) {
 test('factory resolution order is explicit, setting, environment, only installed, tmux-first', () => {
   const tmux = fakeBackend('tmux');
   const zellij = fakeBackend('zellij');
+  const herdr = fakeBackend('herdr');
 
   let setting = 'zellij';
-  let env = { ZELLIJ: '0', TMUX: '/tmp/tmux' };
-  let factory = createMultiplexerFactory({ backends: { tmux, zellij }, getSetting: () => setting, env });
+  let env = { HERDR_ENV: '1', ZELLIJ: '0', TMUX: '/tmp/tmux' };
+  let factory = createMultiplexerFactory({ backends: { tmux, zellij, herdr }, getSetting: () => setting, env });
   assert.equal(factory.getMultiplexer('tmux').name, 'tmux');
+  assert.equal(factory.getMultiplexer('herdr').name, 'herdr');
   assert.equal(factory.getMultiplexer().name, 'zellij');
 
   setting = 'auto';
-  assert.equal(factory.getMultiplexer().name, 'zellij');
+  assert.equal(factory.getMultiplexer().name, 'herdr');
   env = { TMUX: '/tmp/tmux' };
-  factory = createMultiplexerFactory({ backends: { tmux, zellij }, getSetting: () => setting, env });
+  factory = createMultiplexerFactory({ backends: { tmux, zellij, herdr }, getSetting: () => setting, env });
   assert.equal(factory.getMultiplexer().name, 'tmux');
 
   env = {};
   factory = createMultiplexerFactory({
-    backends: { tmux: fakeBackend('tmux', { installed: false }), zellij },
+    backends: {
+      tmux: fakeBackend('tmux', { installed: false }),
+      zellij: fakeBackend('zellij', { installed: false }),
+      herdr,
+    },
+    getSetting: () => 'auto',
+    env,
+  });
+  assert.equal(factory.getMultiplexer().name, 'herdr');
+
+  factory = createMultiplexerFactory({
+    backends: {
+      tmux: fakeBackend('tmux', { installed: false }),
+      zellij,
+      herdr: fakeBackend('herdr', { installed: false }),
+    },
     getSetting: () => 'auto',
     env,
   });
   assert.equal(factory.getMultiplexer().name, 'zellij');
 
-  factory = createMultiplexerFactory({ backends: { tmux, zellij }, getSetting: () => 'auto', env });
+  factory = createMultiplexerFactory({
+    backends: { tmux, zellij, herdr }, getSetting: () => 'auto', env,
+  });
   assert.equal(factory.getMultiplexer().name, 'tmux');
 });
 
@@ -73,6 +92,8 @@ test('multiplexer setting is registered and enum-validated', () => {
     assert.equal(getConfig('multiplexer'), 'auto');
     assert.equal(setConfigValue('multiplexer', 'zellij'), 'zellij');
     assert.equal(getConfig('multiplexer'), 'zellij');
+    assert.equal(setConfigValue('multiplexer', 'herdr'), 'herdr');
+    assert.equal(getConfig('multiplexer'), 'herdr');
     assert.throws(() => setConfigValue('multiplexer', 'screen'), /one of/i);
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/test/notify.test.js
+++ b/test/notify.test.js
@@ -98,6 +98,24 @@ test('zellij intentionally has no statusline notification fallback', () => {
   assert.deepEqual(calls, []);
 });
 
+test('ambient herdr takes precedence over tmux notification fallback', () => {
+  const calls = [];
+  const oldTmux = process.env.TMUX;
+  const oldHerdr = process.env.HERDR_ENV;
+  const oldMux = process.env.UNSNOOZE_MUX;
+  delete process.env.UNSNOOZE_MUX;
+  process.env.TMUX = '/tmp/tmux';
+  process.env.HERDR_ENV = '1';
+  try {
+    notify('x', 'y', { platform: 'freebsd', spawner: (cmd, args) => calls.push({ cmd, args }) });
+  } finally {
+    if (oldTmux === undefined) delete process.env.TMUX; else process.env.TMUX = oldTmux;
+    if (oldHerdr === undefined) delete process.env.HERDR_ENV; else process.env.HERDR_ENV = oldHerdr;
+    if (oldMux === undefined) delete process.env.UNSNOOZE_MUX; else process.env.UNSNOOZE_MUX = oldMux;
+  }
+  assert.deepEqual(calls, []);
+});
+
 test('managed tmux uses its fallback even with nested Zellij environment', () => {
   const calls = [];
   const oldTmux = process.env.TMUX;

--- a/test/resumer.test.js
+++ b/test/resumer.test.js
@@ -77,6 +77,21 @@ test('reopen environment contains only record env and unsnooze control vars', as
   }
 });
 
+test('herdr reopen environment carries the target session as pane owner', async () => {
+  const rec = seed({ mux: 'herdr', pane: null, agent: 'codex', muxSession: 'revive-herdr', paneOwner: 'old-herdr' });
+  let launchSpec;
+  const mux = {
+    sessionExists: async name => name === 'revive-herdr',
+    newWindow: async (_session, _cwd, spec) => {
+      launchSpec = spec;
+      return { pane: 'w1:p1', paneOwner: 'revive-herdr' };
+    },
+  };
+  assert.equal(await dispatchOne(rec, { mux }), 'reopen');
+  assert.equal(launchSpec.env.UNSNOOZE_MUX, 'herdr');
+  assert.equal(launchSpec.env.UNSNOOZE_PANE_OWNER, 'revive-herdr');
+});
+
 test('record with cwd null → reopened in the home dir, not a newWindow crash', async () => {
   const rec = seed({ pane: null, agent: 'codex', cwd: null });
   const windows = [];

--- a/test/spawn-reap.test.js
+++ b/test/spawn-reap.test.js
@@ -62,6 +62,7 @@ test('isUnsnoozeSessionName matches base, numbered, resumed, pid', () => {
 test('attachHint names the right mux attach command', () => {
   assert.equal(attachHint('tmux', 'unsnooze-resumed'), 'tmux attach -t unsnooze-resumed');
   assert.equal(attachHint('zellij', 'unsnooze-resumed'), 'zellij attach unsnooze-resumed');
+  assert.equal(attachHint('herdr', 'unsnooze-resumed'), 'herdr session attach unsnooze-resumed');
   assert.equal(attachHint('tmux', null), null);
 });
 


### PR DESCRIPTION
## What
Adds **herdr** ([herdr.dev](https://herdr.dev) — the agent-aware terminal multiplexer) as a third backend, following the same factory pattern as the zellij backend (#1): a new `src/multiplexers/herdr.js` behind the existing `createMultiplexerFactory` registry, a `multiplexer: herdr` config value, and auto-detection via `HERDR_ENV`.

## How it maps

| unsnooze operation | herdr CLI |
|---|---|
| capturePane / capturePaneVisible | `pane read --source recent\|visible --format text` |
| sendText / sendKey | `pane send-text` / `pane send-keys` |
| paneAlive | `pane get` (parsed JSON, never exit-code trust) |
| paneCurrentCommand | `pane process-info` (argv-preferred over 15-char comm) |
| listSessions / listSessionPanes | `session list --json` / `pane list` |
| newWindow | headless `herdr --session <name> server` → `workspace create` → `pane run` |
| launchWrapped | headless build + foreground `session attach` |

Notable herdr-specific decisions, documented in the module:
- **Env delivery** goes through `workspace create --env` (whitelisted to `UNSNOOZE_*`) because `pane run` types argv into the pane's shell — argv-encoded `/usr/bin/env` is unsafe there. Non-whitelisted env reaches panes via the session server's environment (tmux server-env semantics).
- **No close-on-exit**: herdr panes outlive their command; an exited agent leaves a live shell pane. The resumer's existing lease/foreground-ownership checks already prevent injecting into such panes.
- All CLI calls scrub inherited `HERDR_*` and pass `--session` explicitly — `HERDR_SOCKET_PATH` outranks `HERDR_SESSION` in herdr's socket resolution, so env-based targeting is unsafe from inside a pane.
- **Version floor herdr ≥ 0.7.5** (socket protocol 17), enforced in `available()` and documented in the README; herdr is 0.x and moving fast.

## Scope honesty
tmux and zellij backends are byte-unchanged. Shared call sites got a third branch: factory registry, settings enum, hook, launcher, notify, fleet — plus reap, prompt-queue, resumer, and report, found by a full sweep for backend-name branching.

## Testing
- 903/903 unit tests (was 888): new `test/multiplexer-herdr.test.js` (fixtures from live herdr 0.7.5 probes) + per-branch wiring tests.
- `scripts/e2e-herdr.sh`: headless smoke battery against a scratch `--session` (mirrors `e2e-zellij.sh`), run twice, leaves no sessions behind.
- `scripts/e2e-simulate.sh` (tmux) still green — regression check.
- Live acceptance on a real machine: wrapped `unsnooze claude` into herdr, real limit banner, StopFailure hook + monitor-scrape both recorded the herdr address, resumer sent the resume via `herdr … send-text` and verified resumption.

Follow-up candidates (separate PRs, if you're interested): NDJSON socket event subscriptions instead of scrape-polling; `pane report-agent` so limit-stopped panes show in herdr's sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
