### PR TITLE
feat: Add support for cmux terminal multiplexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ password hosts on Windows; a plain `ssh <host>` prompt works with native
 
 | key | default | meaning |
 |---|---|---|
-| `multiplexer` | `auto` | Backend to use: `auto`, `tmux`, or `zellij`. `auto` prefers the current multiplexer, then the only installed backend, with tmux as the tie-breaker. |
+| `multiplexer` | `auto` | Backend to use: `auto`, `tmux`, `zellij`, or `cmux`. `auto` prefers the current multiplexer (tmux/zellij ambient env, then `CMUX_SOCKET_PATH`); with no ambient env it falls back to whichever of tmux/zellij is installed, tmux as the tie-breaker — cmux is only selected via its ambient env or an explicit setting, never by this installed-backend fallback, since it has no attach-from-outside path to wrap into. cmux support covers resume-in-place (detect, capture, send); it has no joinable named-session model, so idle-session reaping (`unsnooze reap`) does not cover cmux panes, and no attach hint is shown for cmux sessions. |
 | `autoResume` | `true` | Master switch. Off = stops are still tracked, but nothing is resumed until you run `unsnooze resume-now` or turn it back on. |
 | `menuAutoAnswer` | `true` | May unsnooze answer Claude's limit menu (send keys in your pane)? Off = watch-only. |
 | `notifications` | `true` | Master switch for all notifications (limit detected / session resumed / gave up). Off = silence every channel. |

--- a/src/config.js
+++ b/src/config.js
@@ -75,7 +75,9 @@ export const LEASE_GRACE_MS = envInt('UNSNOOZE_LEASE_GRACE_MS', 60_000);
 // this list. It lives here, in a module that imports nothing but node builtins,
 // because settings.js and multiplexer.js already import each other — declaring
 // it in either one puts the other in a temporal dead zone at import time.
-export const MUX_NAMES = ['tmux', 'zellij'];
+// cmux is last: an agent can run tmux inside a cmux surface, so tmux/zellij
+// must win detection when both are signalled (see multiplexer.js: detect()).
+export const MUX_NAMES = ['tmux', 'zellij', 'cmux'];
 
 // Pane scanning
 export const PANE_SCAN_LINES = envInt('UNSNOOZE_PANE_SCAN_LINES', 12);

--- a/src/fleet.js
+++ b/src/fleet.js
@@ -845,6 +845,9 @@ export const MUX_SESSION_RE = /^[A-Za-z0-9_.-]{1,64}$/;
 // validation — callers must treat null as "omit the attach line".
 export function attachHintRemote(dest, muxName, muxSession) {
   if (!validHostToken(dest) || typeof muxSession !== 'string' || !MUX_SESSION_RE.test(muxSession)) return null;
+  // cmux has no joinable named-session model — there is no remote command
+  // that reattaches to a surface, so omit the hint (see reap.js: attachHint).
+  if (muxName === 'cmux') return null;
   const inner = muxName === 'zellij' ? `zellij attach ${muxSession}` : `tmux new -A -s ${muxSession}`;
   return `ssh -t ${dest} '${inner}'`;
 }

--- a/src/multiplexer.js
+++ b/src/multiplexer.js
@@ -1,10 +1,11 @@
 import tmux from './multiplexers/tmux.js';
 import zellij from './multiplexers/zellij.js';
+import cmux from './multiplexers/cmux.js';
 import { getConfig } from './settings.js';
 import { MUX_NAMES as NAMES } from './config.js';
 
 export function createMultiplexerFactory({
-  backends = { tmux, zellij },
+  backends = { tmux, zellij, cmux },
   getSetting = () => getConfig('multiplexer'),
   env = process.env,
 } = {}) {
@@ -31,6 +32,10 @@ export function createMultiplexerFactory({
 
     if (env.ZELLIJ) return 'zellij';
     if (env.TMUX) return 'tmux';
+    // Checked after tmux/zellij: an agent can run tmux inside a cmux surface,
+    // in which case both TMUX and CMUX_SOCKET_PATH are set and the inner
+    // tmux session is what should be driven.
+    if (env.CMUX_SOCKET_PATH) return 'cmux';
 
     const tmuxInstalled = isAvailable('tmux');
     const zellijInstalled = isAvailable('zellij');

--- a/src/multiplexers/cmux.js
+++ b/src/multiplexers/cmux.js
@@ -1,0 +1,144 @@
+import { execFile as execFileCb, spawnSync } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { SessionCreateError } from './session-name.js';
+
+const execFileAsync = promisify(execFileCb);
+
+function defaultSpawner(file, args, { sync = false, ...options } = {}) {
+  if (sync) return spawnSync(file, args, options);
+  return execFileAsync(file, args, options).then(({ stdout }) => stdout);
+}
+
+export const SUBMIT_DELAY_MS = 150;
+
+export { SessionCreateError };
+
+// cmux's `send-key` takes a small lowercase key vocabulary (enter, tab,
+// escape, backspace, delete, up, down, left, right); unsnooze only ever asks
+// for these three capitalized, tmux-style names, so translate them.
+const KEY_NAMES = { Enter: 'enter', Up: 'up', Down: 'down' };
+
+// `--command` is typed into the new workspace's real shell as a literal
+// keystroke line (cmux has no argv-exec launch path like tmux/zellij), so the
+// wrapped file+args must be assembled into valid, single-quoted shell syntax.
+function shQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function argvLine(launchSpec) {
+  return [launchSpec.file, ...(launchSpec.args || [])].map(shQuote).join(' ');
+}
+
+function envArgs(env = {}) {
+  return Object.entries(env)
+    .filter(([, value]) => value !== undefined)
+    .flatMap(([key, value]) => ['--env', `${key}=${value}`]);
+}
+
+export function createCmux({ spawner = defaultSpawner, env = process.env } = {}) {
+  const run = (...args) => spawner('cmux', args);
+
+  const backend = {
+    name: 'cmux',
+    SUBMIT_DELAY_MS,
+
+    available() {
+      try {
+        return spawner('cmux', ['--version'], { sync: true, stdio: 'ignore' }).status === 0;
+      } catch {
+        return false;
+      }
+    },
+
+    inside() { return !!env.CMUX_SOCKET_PATH; },
+    currentPaneId() {
+      if (env.UNSNOOZE_MUX === 'cmux' && env.UNSNOOZE_PANE) return env.UNSNOOZE_PANE;
+      return env.CMUX_SURFACE_ID || null;
+    },
+
+    async capturePane(pane, lines = 200) {
+      return run('read-screen', '--surface', pane, '--scrollback', '--lines', String(lines));
+    },
+
+    async capturePaneVisible(pane) {
+      return run('read-screen', '--surface', pane);
+    },
+
+    async sendText(pane, text) {
+      await run('send', '--surface', pane, '--', text);
+      await new Promise(resolve => setTimeout(resolve, SUBMIT_DELAY_MS));
+      await run('send-key', '--surface', pane, 'enter');
+    },
+
+    async sendKey(pane, key) {
+      await run('send-key', '--surface', pane, KEY_NAMES[key] || String(key).toLowerCase());
+    },
+
+    // cmux's v2 socket returns an explicit `not_found` error (non-zero exit)
+    // for a missing surface — verified against a live cmux instance — unlike
+    // tmux 3.7b's blank-line/exit-0 quirk for a stale target. A thrown read
+    // is therefore trustworthy evidence the surface is gone.
+    async paneAlive(pane) {
+      try {
+        await run('read-screen', '--surface', pane);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    // cmux has no tmux/zellij-style joinable named session: every revival
+    // opens a fresh workspace (cmux's window/tab unit) and types the wrapped
+    // command into its default shell. `workspace create --json` echoes the
+    // new default surface's ref directly, so no follow-up lookup is needed.
+    async newWindow(sessionName, cwd, launchSpec) {
+      const out = await run('--json', 'workspace', 'create',
+        '--name', sessionName, '--cwd', cwd, '--command', argvLine(launchSpec),
+        ...envArgs(launchSpec.env));
+      let parsed;
+      try {
+        parsed = JSON.parse(out);
+      } catch {
+        throw new Error(`unsnooze: unexpected cmux workspace create output: ${String(out).slice(0, 200)}`);
+      }
+      const pane = parsed.surface_ref || parsed.surface_id;
+      if (!pane) throw new Error('unsnooze: cmux workspace create returned no surface');
+      return { pane, paneOwner: null };
+    },
+
+    // cmux is a native GUI terminal the agent is expected to already be
+    // running inside (that's the premise this driver detects), not something
+    // launched fresh and attached to synchronously from a plain shell the way
+    // tmux/zellij are — there is no session to wrap into from outside it.
+    launchWrapped() {
+      throw new SessionCreateError(
+        'cmux sessions cannot be started from outside cmux — open a workspace in cmux and run the command there');
+    },
+
+    async closePane(pane) {
+      await run('close-surface', '--surface', pane);
+    },
+
+    // Surface ids are cmux-global handles, not scoped to an owning session
+    // (like tmux pane ids), so owner binding is inert.
+    bind() { return backend; },
+  };
+
+  return backend;
+}
+
+const cmux = createCmux();
+
+export const available = (...args) => cmux.available(...args);
+export const inside = (...args) => cmux.inside(...args);
+export const currentPaneId = (...args) => cmux.currentPaneId(...args);
+export const capturePane = (...args) => cmux.capturePane(...args);
+export const capturePaneVisible = (...args) => cmux.capturePaneVisible(...args);
+export const sendText = (...args) => cmux.sendText(...args);
+export const sendKey = (...args) => cmux.sendKey(...args);
+export const paneAlive = (...args) => cmux.paneAlive(...args);
+export const newWindow = (...args) => cmux.newWindow(...args);
+export const launchWrapped = (...args) => cmux.launchWrapped(...args);
+
+export default cmux;

--- a/src/multiplexers/cmux.js
+++ b/src/multiplexers/cmux.js
@@ -2,6 +2,7 @@ import { execFile as execFileCb, spawnSync } from 'node:child_process';
 import { promisify } from 'node:util';
 
 import { SessionCreateError } from './session-name.js';
+import { shellCommand } from './shell-quote.js';
 
 const execFileAsync = promisify(execFileCb);
 
@@ -18,17 +19,6 @@ export { SessionCreateError };
 // escape, backspace, delete, up, down, left, right); unsnooze only ever asks
 // for these three capitalized, tmux-style names, so translate them.
 const KEY_NAMES = { Enter: 'enter', Up: 'up', Down: 'down' };
-
-// `--command` is typed into the new workspace's real shell as a literal
-// keystroke line (cmux has no argv-exec launch path like tmux/zellij), so the
-// wrapped file+args must be assembled into valid, single-quoted shell syntax.
-function shQuote(value) {
-  return `'${String(value).replace(/'/g, "'\\''")}'`;
-}
-
-function argvLine(launchSpec) {
-  return [launchSpec.file, ...(launchSpec.args || [])].map(shQuote).join(' ');
-}
 
 function envArgs(env = {}) {
   return Object.entries(env)
@@ -104,9 +94,17 @@ export function createCmux({ spawner = defaultSpawner, env = process.env } = {})
     // command into its default shell. `workspace create --json` echoes the
     // new default surface's ref directly, so no follow-up lookup is needed.
     async newWindow(sessionName, cwd, launchSpec) {
+      // `--command` is typed into the new workspace's real shell as a literal
+      // keystroke line (cmux has no argv-exec launch path like tmux/zellij), so
+      // the quoting is ours to do — and an argument holding a newline or a tab
+      // cannot be typed at all, since the terminal reads those as submit and
+      // complete. shellCommand() hoists any such argument into the workspace
+      // environment and references it from the line, so a multi-paragraph
+      // resumeMessage still reaches the agent as one argument.
+      const { line, env: argEnv } = shellCommand(launchSpec.file, launchSpec.args || []);
       const out = await run('--json', 'workspace', 'create',
-        '--name', sessionName, '--cwd', cwd, '--command', argvLine(launchSpec),
-        ...envArgs(launchSpec.env));
+        '--name', sessionName, '--cwd', cwd, '--command', line,
+        ...envArgs({ ...launchSpec.env, ...argEnv }));
       let parsed;
       try {
         parsed = JSON.parse(out);

--- a/src/multiplexers/cmux.js
+++ b/src/multiplexers/cmux.js
@@ -43,6 +43,17 @@ export function createCmux({ spawner = defaultSpawner, env = process.env } = {})
     name: 'cmux',
     SUBMIT_DELAY_MS,
 
+    // Unlike tmux/zellij, where the binary IS the server (a missing session
+    // just gets started on demand), cmux's binary is a thin socket client:
+    // `--version` only proves the CLI is on PATH, not that the cmux app is
+    // running. A cmux that's installed but not open still passes this check,
+    // then fails every real operation with a socket connection error. That's
+    // an accepted gap here — every socket call already degrades gracefully
+    // (paneAlive/capturePane return false/throw, launchWrapped/newWindow
+    // throw and get caught upstream) — but it does mean this signal alone
+    // can't tell "not installed" apart from "installed, not running" for
+    // status/setup messaging (doctor.js, wizard.js) the way it can for
+    // tmux/zellij.
     available() {
       try {
         return spawner('cmux', ['--version'], { sync: true, stdio: 'ignore' }).status === 0;

--- a/src/reap.js
+++ b/src/reap.js
@@ -82,8 +82,12 @@ function restoreFailedClaim(rec) {
 }
 
 // How a user reaches a revived session. Shared by status, toast, and `sessions`.
+// cmux has no joinable named-session model (see multiplexers/cmux.js) — there
+// is no command that attaches to a surface from outside cmux, so omit the hint
+// rather than print a `tmux attach` that would silently do nothing useful.
 export function attachHint(muxName, sessionName) {
   if (!sessionName) return null;
+  if (muxName === 'cmux') return null;
   if (muxName === 'zellij') return `zellij attach ${sessionName}`;
   return `tmux attach -t ${sessionName}`;
 }

--- a/src/settings.js
+++ b/src/settings.js
@@ -13,7 +13,7 @@ import { MUX_NAMES, STATE_DIR } from './config.js';
 export const CONFIG_FILE = () => join(process.env.UNSNOOZE_STATE_DIR || STATE_DIR, 'config.json');
 
 export const DEFAULTS = {
-  multiplexer: 'auto',    // auto | tmux | zellij
+  multiplexer: 'auto',    // auto | tmux | zellij | cmux
   autoResume: true,        // master switch: dispatch resumes when limits reset
   menuAutoAnswer: true,    // may unsnooze drive Claude's limit menu (send keys)?
   notifications: true,     // desktop notifications on detect/resume

--- a/test/fleet.test.js
+++ b/test/fleet.test.js
@@ -295,6 +295,11 @@ test('attachHintRemote: a clean muxSession still round-trips', async () => {
   assert.equal(attachHintRemote('build1', 'zellij', 'my-session.1_2'), `ssh -t build1 'zellij attach my-session.1_2'`);
 });
 
+test('attachHintRemote omits the hint for cmux — there is no remote attach command', async () => {
+  const { attachHintRemote } = await import('../src/fleet.js');
+  assert.equal(attachHintRemote('gpu', 'cmux', 'unsnooze-resumed'), null);
+});
+
 test('fleet table/json path: hostile muxSession produces no attach line', async () => {
   const { fetchFleet, formatFleetTui } = await import('../src/fleet.js');
   const evilSession = frameIt({

--- a/test/multiplexer.test.js
+++ b/test/multiplexer.test.js
@@ -603,6 +603,30 @@ test('cmux newWindow creates a workspace, shell-quotes argv for keystroke typing
   ]);
 });
 
+test('cmux newWindow carries an untypeable argument as environment, not keystrokes', async () => {
+  // `--command` is typed into the workspace's shell, so a newline in it submits
+  // half a command and the remainder runs as its own command. Quoting cannot
+  // prevent that — the value has to travel out of band.
+  const spawner = fakeSpawner((_file, args) => {
+    if (args.includes('create')) return JSON.stringify({ surface_ref: 'surface:9' });
+    return '';
+  });
+  const mux = createCmux({ spawner, env: {} });
+  const message = 'Continue where you left off.\n\nFocus on the failing test first.';
+
+  await mux.newWindow('revival', '/tmp', {
+    file: 'node', args: ['_run', 'codex', 'resume', '01J', message], env: { LEASE: 'xyz' },
+  });
+
+  const args = spawner.calls[0].args;
+  const command = args[args.indexOf('--command') + 1];
+  assert.doesNotMatch(command, /\n/, 'nothing with a newline in it may be typed');
+  assert.equal(command, `'node' '_run' 'codex' 'resume' '01J' "$UNSNOOZE_ARGV_5"`);
+  assert.ok(args.includes(`UNSNOOZE_ARGV_5=${message}`),
+    'the message rides in the workspace environment, where cmux passes it as real argv');
+  assert.ok(args.includes('LEASE=xyz'), 'and the caller\'s own environment still goes through');
+});
+
 test('cmux newWindow throws when workspace create returns no surface reference', async () => {
   const spawner = fakeSpawner(() => JSON.stringify({ workspace_ref: 'workspace:3' }));
   const mux = createCmux({ spawner, env: {} });

--- a/test/multiplexer.test.js
+++ b/test/multiplexer.test.js
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 
 import { createTmux } from '../src/multiplexers/tmux.js';
 import { createZellij } from '../src/multiplexers/zellij.js';
+import { createCmux } from '../src/multiplexers/cmux.js';
 import { createMultiplexerFactory } from '../src/multiplexer.js';
 import { DEFAULTS, getConfig, setConfigValue } from '../src/settings.js';
 import { MUX_NAMES } from '../src/config.js';
@@ -74,6 +75,8 @@ test('multiplexer setting is registered and enum-validated', () => {
     assert.equal(getConfig('multiplexer'), 'auto');
     assert.equal(setConfigValue('multiplexer', 'zellij'), 'zellij');
     assert.equal(getConfig('multiplexer'), 'zellij');
+    assert.equal(setConfigValue('multiplexer', 'cmux'), 'cmux');
+    assert.equal(getConfig('multiplexer'), 'cmux');
     assert.throws(() => setConfigValue('multiplexer', 'screen'), /one of/i);
     // The enum tracks MUX_NAMES: a backend registered in config.js is settable
     // without touching settings.js, which is what keeps backend PRs conflict-free.
@@ -521,4 +524,141 @@ test('zellij capturePane falls back to viewport when --full is unsupported (pre-
   await mux.capturePane('3');
   const fullAttempts = spawner.calls.filter(c => c.args.includes('--full')).length;
   assert.equal(fullAttempts, 1, 'unsupported --full is remembered, not retried every tick');
+});
+
+test('cmux backend probes, inside(), and currentPaneId prefer the managed unsnooze pane', () => {
+  const spawner = fakeSpawner(() => ({ status: 0 }));
+  const env = { CMUX_SOCKET_PATH: '/tmp/cmux.sock', CMUX_SURFACE_ID: 'surface:1' };
+  const mux = createCmux({ spawner, env });
+  assert.equal(mux.available(), true);
+  assert.deepEqual(spawner.calls[0].args, ['--version']);
+  assert.equal(mux.inside(), true);
+  assert.equal(mux.currentPaneId(), 'surface:1');
+
+  const managed = createCmux({
+    spawner: fakeSpawner(),
+    env: { ...env, UNSNOOZE_MUX: 'cmux', UNSNOOZE_PANE: 'surface:managed' },
+  });
+  assert.equal(managed.currentPaneId(), 'surface:managed');
+
+  assert.equal(createCmux({ spawner: fakeSpawner(), env: {} }).inside(), false);
+});
+
+test('cmux capturePane requests scrollback with a line limit; capturePaneVisible does not', async () => {
+  const spawner = fakeSpawner(() => 'screen text');
+  const mux = createCmux({ spawner, env: {} });
+  assert.equal(await mux.capturePane('surface:7', 50), 'screen text');
+  assert.deepEqual(spawner.calls[0].args,
+    ['read-screen', '--surface', 'surface:7', '--scrollback', '--lines', '50']);
+  assert.equal(await mux.capturePaneVisible('surface:7'), 'screen text');
+  assert.deepEqual(spawner.calls[1].args, ['read-screen', '--surface', 'surface:7']);
+});
+
+test('cmux sendText types the literal text then presses enter as a separate call', async () => {
+  const spawner = fakeSpawner(() => '');
+  const mux = createCmux({ spawner, env: {} });
+  await mux.sendText('surface:1', 'hello');
+  assert.deepEqual(spawner.calls[0].args, ['send', '--surface', 'surface:1', '--', 'hello']);
+  assert.deepEqual(spawner.calls[1].args, ['send-key', '--surface', 'surface:1', 'enter']);
+});
+
+test('cmux sendKey maps unsnooze\'s capitalized key names to cmux\'s lowercase vocabulary', async () => {
+  const spawner = fakeSpawner(() => '');
+  const mux = createCmux({ spawner, env: {} });
+  await mux.sendKey('surface:1', 'Down');
+  assert.deepEqual(spawner.calls[0].args, ['send-key', '--surface', 'surface:1', 'down']);
+  await mux.sendKey('surface:1', 'Up');
+  assert.deepEqual(spawner.calls[1].args, ['send-key', '--surface', 'surface:1', 'up']);
+  await mux.sendKey('surface:1', 'Enter');
+  assert.deepEqual(spawner.calls[2].args, ['send-key', '--surface', 'surface:1', 'enter']);
+});
+
+test('cmux paneAlive trusts read-screen\'s exit status — cmux errors explicitly instead of tmux\'s blank-success quirk', async () => {
+  const alive = createCmux({ spawner: fakeSpawner(() => ''), env: {} });
+  assert.equal(await alive.paneAlive('surface:1'), true);
+
+  const dead = createCmux({
+    spawner: fakeSpawner(() => { throw new Error('not_found: Surface not found for the given surface_id'); }),
+    env: {},
+  });
+  assert.equal(await dead.paneAlive('surface:1'), false);
+});
+
+test('cmux newWindow creates a workspace, shell-quotes argv for keystroke typing, and returns the created surface ref', async () => {
+  const spawner = fakeSpawner((_file, args) => {
+    if (args.includes('create')) return JSON.stringify({ workspace_ref: 'workspace:3', surface_ref: 'surface:9' });
+    return '';
+  });
+  const mux = createCmux({ spawner, env: {} });
+
+  const created = await mux.newWindow('revival', '/tmp/project', {
+    file: '/usr/bin/node', args: ['agent.js', '--resume', "abc's session"], env: { LEASE: 'xyz', EMPTY: '' },
+  });
+
+  assert.deepEqual(created, { pane: 'surface:9', paneOwner: null });
+  assert.deepEqual(spawner.calls[0].args, [
+    '--json', 'workspace', 'create', '--name', 'revival', '--cwd', '/tmp/project',
+    '--command', "'/usr/bin/node' 'agent.js' '--resume' 'abc'\\''s session'",
+    '--env', 'LEASE=xyz', '--env', 'EMPTY=',
+  ]);
+});
+
+test('cmux newWindow throws when workspace create returns no surface reference', async () => {
+  const spawner = fakeSpawner(() => JSON.stringify({ workspace_ref: 'workspace:3' }));
+  const mux = createCmux({ spawner, env: {} });
+  await assert.rejects(
+    () => mux.newWindow('revival', '/tmp', { file: 'claude', args: [], env: {} }),
+    /no surface/,
+  );
+});
+
+test('cmux newWindow throws on unparseable workspace create output', async () => {
+  const spawner = fakeSpawner(() => 'not json');
+  const mux = createCmux({ spawner, env: {} });
+  await assert.rejects(
+    () => mux.newWindow('revival', '/tmp', { file: 'claude', args: [], env: {} }),
+    /unexpected cmux workspace create output/,
+  );
+});
+
+test('cmux launchWrapped always throws SessionCreateError — there is no attach-from-outside path', () => {
+  const mux = createCmux({ spawner: fakeSpawner(), env: {} });
+  assert.throws(
+    () => mux.launchWrapped({ file: 'node', args: [], env: {} }),
+    err => err.name === 'SessionCreateError',
+  );
+});
+
+test('cmux closePane targets close-surface', async () => {
+  const spawner = fakeSpawner(() => '');
+  const mux = createCmux({ spawner, env: {} });
+  await mux.closePane('surface:1');
+  assert.deepEqual(spawner.calls[0].args, ['close-surface', '--surface', 'surface:1']);
+});
+
+test('cmux bind is inert — surface ids are global handles, not scoped to an owning session', () => {
+  const mux = createCmux({ spawner: fakeSpawner(), env: {} });
+  assert.equal(mux.bind('anything'), mux);
+});
+
+test('factory prefers ambient tmux/zellij over cmux, but resolves cmux when only its socket env is set', () => {
+  const tmux = fakeBackend('tmux');
+  const zellij = fakeBackend('zellij');
+  const cmux = fakeBackend('cmux');
+  const backends = { tmux, zellij, cmux };
+
+  let env = { TMUX: '/tmp/tmux', CMUX_SOCKET_PATH: '/tmp/cmux.sock' };
+  let factory = createMultiplexerFactory({ backends, getSetting: () => 'auto', env });
+  assert.equal(factory.getMultiplexer().name, 'tmux');
+
+  env = { ZELLIJ: '0', CMUX_SOCKET_PATH: '/tmp/cmux.sock' };
+  factory = createMultiplexerFactory({ backends, getSetting: () => 'auto', env });
+  assert.equal(factory.getMultiplexer().name, 'zellij');
+
+  env = { CMUX_SOCKET_PATH: '/tmp/cmux.sock' };
+  factory = createMultiplexerFactory({ backends, getSetting: () => 'auto', env });
+  assert.equal(factory.getMultiplexer().name, 'cmux');
+
+  factory = createMultiplexerFactory({ backends, getSetting: () => 'cmux', env: {} });
+  assert.equal(factory.getMultiplexer().name, 'cmux');
 });

--- a/test/spawn-reap.test.js
+++ b/test/spawn-reap.test.js
@@ -78,6 +78,10 @@ test('attachHint names the right mux attach command', () => {
   assert.equal(attachHint('tmux', null), null);
 });
 
+test('attachHint omits the hint for cmux — there is no attach-from-outside command', () => {
+  assert.equal(attachHint('cmux', 'unsnooze-resumed'), null);
+});
+
 test('reap dry-run kills nothing', async () => {
   const state = upsertSession({
     sessionId: 'reap-dry-1',


### PR DESCRIPTION
## Summary

Adds a `cmux` multiplexer driver alongside `tmux` and `zellij`, closing #10.

- **Detection:** `CMUX_SOCKET_PATH`, checked in auto-detection *after* tmux/zellij's own ambient env — an agent can run tmux inside a cmux surface, in which case the inner tmux session is what should be driven.
- **Pane capture:** `cmux read-screen --surface <id>` (visible) / `--scrollback --lines <n>` (scrollback).
- **Text/keystroke delivery:** `cmux send --surface <id> -- <text>` then a separate `cmux send-key --surface <id> enter` (mirrors the existing tmux/zellij two-step submit, needed so Ink doesn't treat Enter as bracketed paste). `sendKey` maps unsnooze's `Enter`/`Up`/`Down` to cmux's lowercase key vocabulary.
- **Liveness:** `paneAlive` trusts `read-screen`'s exit status — verified live that cmux returns an explicit `not_found` error for a missing surface, unlike tmux 3.7b's known blank-line/exit-0 quirk for a stale target (see the comment/tests).
- **Reviving a dead session:** `newWindow` uses `cmux workspace create --json` (not the deprecated `new-workspace`, which doesn't emit parseable JSON) and returns the new surface ref directly from the response.

### Scope: architectural mismatch with tmux/zellij

cmux is a native GUI terminal the agent is expected to already be running inside — not a background session server you attach to from a plain shell the way tmux/zellij are. Two consequences, called out explicitly rather than left as silent gaps:

- **`launchWrapped` always throws `SessionCreateError`.** There's no cmux command that starts a session from outside cmux and blocks in the foreground the way `tmux new-session` does; this degrades gracefully to running unwatched (same path as a missing tmux/zellij binary).
- **No joinable named-session model**, so `unsnooze reap` (idle-session cleanup) and the `attach: …` hint (`reap.js`/`fleet.js`) don't cover cmux — both are now explicitly guarded off for `muxName === 'cmux'` rather than falling through to a bogus `tmux attach -t <session>` line (a real bug caught and fixed by `/code-review` during this change, with regression tests).
- **`available()` can't tell "not installed" apart from "installed but not running."** cmux's CLI is a thin socket client, not a self-starting server like tmux/zellij — `cmux --version` passes without touching the socket, so it's true even when the app isn't open. Every real operation still degrades safely either way (socket calls throw, `paneAlive`/`capturePane` fail closed), but `doctor.js`/`wizard.js`'s "not installed — install it" messaging would be misleading for an installed-but-closed cmux. Documented in a code comment rather than fixed, since a proper fix needs a distinct status touching those shared files (used by tmux/zellij too) rather than the driver itself — happy to follow up if that's wanted.

In short: resume-in-place (detect a stopped session, capture its pane, type the resume message) is fully supported. Session-lifecycle parity (list/attach/reap) is narrower, matching cmux's workspace-plus-keystroke-injection model rather than tmux/zellij's process-exec session model.

All commands were verified against the real cmux CLI (`docs/cli-contract.md` in manaflow-ai/cmux, plus a live cmux instance) rather than the CLI surface sketched in the issue — `capture-pane`/`read-screen` and `workspace create`'s JSON output shape aren't quite what the issue's proposed implementation suggested.

## Test plan

- [x] `npm test` — 965/965 passing (was 963; +2 regression tests from the `attachHint` fix)
- [x] New unit tests in `test/multiplexer.test.js` covering detection order, capture, send/send-key, paneAlive, newWindow (incl. shell-quoting for the typed `--command`), launchWrapped, closePane, and bind
- [x] `/code-review` (medium) run and fixes applied
- [x] Live scripted verification against a real, running cmux instance (this session is itself running inside a cmux surface): `read-screen` on a valid surface, `read-screen` on a bogus/closed surface (confirms the `not_found` error `paneAlive` relies on), `ping`, `capabilities` (confirms `surface.read_text`/`send_text`/`send_key`, `workspace.create` are live methods)
- [ ] Full interactive end-to-end (simulate a rate-limited CLI in a cmux surface, wait for reset, verify auto-resume) — not run; would require driving cmux's GUI itself, out of reach for a scripted session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011St9eoQoUWKwhi1af1iXYs
