### PR TITLE
1.17.0 — a state lock that could spin forever, and a state directory anyone could read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,134 @@
 # Changelog
 
+## 1.17.0 — 2026-08-23
+
+- **A state directory unsnooze cannot write to no longer pins a CPU core
+  forever.** The lock around `~/.unsnooze/state.json` treated every `mkdir`
+  failure as contention. `EEXIST` really is contention — someone else holds the
+  lock — but `EACCES` on an unwritable state directory, `EROFS` on a read-only
+  filesystem and `ENOSPC` on a full one are not, and that branch retried with
+  neither a sleep nor a deadline check. Since `mkdir -p` on a directory that
+  already exists succeeds as a no-op, there was nothing to break the cycle:
+  the loop spun at around 70% of a core, ignored `UNSNOOZE_LOCK_TIMEOUT_MS`
+  entirely, and never returned. It took every writer with it — the daemon, any
+  CLI command, and the StopFailure hook that runs *inside* your agent. unsnooze
+  now repairs a state directory it owns and otherwise fails on the deadline with
+  the errno that caused it.
+
+- **Everything under `~/.unsnooze` is now owner-only (0700 / 0600).** The
+  directory was 0755 and every file inside it 0644, so on a shared machine any
+  other local user could read them. That directory holds your ntfy bearer token
+  (`config.json`), the text of queued prompts and the paths they run in
+  (`state.json`), your fleet's ssh destinations and the commands that fetch
+  their passwords (`hosts.json`), a mirror of every remote host's sessions
+  (`fleet-cache.json`), a lease file per pane carrying its working directory
+  (`leases/`), and — for a headless revival — the entire stdout and stderr of
+  an unattended agent run (`headless/*.log`). Every writer now creates its file
+  owner-only and its directory 0700.
+
+  Upgrading an existing install needed more than that, because none of it is
+  something a writer can fix: `mkdir`'s mode is ignored for a directory that
+  already exists, appending to a log reuses the file's inode, and
+  `config.json` and `hosts.json` are written only by `config set` and
+  `hosts add`, so an install that never touches them again would have kept
+  their old mode — and the token in one of them — indefinitely. So a state
+  write repairs the modes directly, walking the `events/`, `leases/`,
+  `mux-sessions/` and `headless/` subdirectories as well as the top-level
+  files. It re-checks on an interval rather than once per process, because
+  `daemon.log` is created by launchd/systemd redirecting the daemon's stdout
+  and can appear after a first pass has already run — in a process that then
+  lives for days. It strips group and other access without touching the
+  owner's own bits, so an executable in there stays executable; it never
+  follows a symlink or a hardlink into a file it is about to change; and it
+  only ever touches unsnooze's own state directory. `unsnooze doctor` reports
+  from the same walk the repair acts on, so the two cannot disagree about what
+  counts as exposed. It is inert on Windows, which has no POSIX mode bits —
+  libuv synthesises them by mirroring the owner's, so every file there reads
+  as world-readable and no `chmod` can change it; access is governed by the
+  profile ACL instead. The same is true of a state directory on a filesystem
+  that does not implement permissions at all — a CIFS or vfat mount, WSL's
+  `drvfs`, a bind mount from a Windows host — and the platform name does not
+  identify those, so unsnooze finds out by attempting the change and looking:
+  a `chmod` that succeeds while the bits stay put means the filesystem has
+  nothing to set, and the directory is left alone rather than rewritten every
+  minute forever. `unsnooze doctor --fix` reports those three outcomes
+  separately, so "could not" is never printed as "did".
+
+  The statusline shim's own drop directory, `~/.claude/unsnooze`, gets the
+  same treatment: it holds your live rate-limit numbers and was created 0755.
+  It is repaired on the shim's next run rather than only for new installs.
+
+  `unsnooze doctor` now also reports anything under the state directory that
+  other users can read, and `doctor --fix` narrows it. That check exists
+  because the repair deliberately ignores a failed `chmod` — crashing every
+  state write on a filesystem that has no usable one would be the worse bug —
+  so something has to be able to tell you it did not take.
+
+  No credential was ever stored in plaintext: a password source is a
+  *reference* to your keychain, environment or secret tool, never the secret.
+  On a single-user machine nothing here was reachable by anyone new.
+
+- **A hostile `session_id` can no longer steer where unsnooze reads or
+  writes.** Three places took that value — which arrives in a payload from the
+  agent — and used it directly as a filename. The opt-in Claude Code statusline
+  shim built its drop filename by concatenating it, so a `/` or a `..` walked
+  the write out of `~/.claude/unsnooze` and over any `.json` file you can
+  write. `transcriptPath`, on the StopFailure hook path that everyone has
+  enabled, composed a transcript path the same way, turning a read of your own
+  transcript into a read of any `.jsonl` you name. And the Kimi adapter probed
+  for a session directory by the same concatenation, which leaked whether an
+  arbitrary path exists. Claude Code sends a uuid, so all three needed a
+  malicious or compromised agent to reach, and the two reads are only ever
+  mined for a timestamp or a boolean — never echoed back. None of them was in
+  a position to know that. All three now require a filename-shaped id and fall
+  back to `unknown` / no-transcript / not-found. If you have the statusline
+  shim installed, re-run `unsnooze usage --install-statusline` to pick up the
+  fix; the other two need nothing.
+
+- **A corrupt `state.json` no longer prints its own first bytes into the log.**
+  The quarantine message included V8's `JSON.parse` error, and V8 embeds a
+  snippet of the input it choked on — so a state file that had been replaced
+  with something else echoed that file's opening characters into
+  `unsnooze.log`. The quarantined file is still kept on disk, and the log still
+  names it and says why.
+
+- **Three narrower lock fixes.** A writer whose stale-lock steal was itself
+  stolen no longer deletes the thief's lock on the way out — it only removes a
+  lock still stamped with its own pid. The steal itself now re-checks that the
+  directory it is about to remove is still the one it judged stale, narrowing
+  a window where two contenders could both decide to steal and the slower one
+  would delete the winner's fresh lock. And a lock is now stolen on age alone
+  once it is very old: liveness was decided by signalling the recorded pid,
+  which cannot tell "unsnooze is still working" from "that number now belongs
+  to some unrelated long-lived process", so a leaked lock whose pid was later
+  recycled wedged every writer permanently, with no recovery but deleting the
+  directory by hand.
+
+  That last one is a trade rather than a free win — stealing from a holder that
+  really is still working puts two writers in the critical section, and one
+  overwrites the other. It is chosen because a permanent wedge is the worse
+  failure, and the exposure is kept small by making sure the lock is only ever
+  held for in-memory work plus a single write: `upsertSession` used to compute
+  its workspace fingerprint inside the lock, which shells out to git, and
+  `execFileSync`'s timeout is a soft bound — it signals the child and then
+  waits for it to actually exit, which a git wedged on a hung network mount
+  never does. That call now happens before the lock is taken, so nothing
+  unbounded runs inside it.
+
+  *Raised in [#17](https://github.com/saaranshM/unsnooze/issues/17). The report
+  also flagged the askpass `command` source as command injection and reading
+  `state.json` as a symlink-following bug; neither is a vulnerability. A
+  `command` source is your own configured command, in the shape git's
+  `credential.helper = !cmd` has always taken, and it can only be set by
+  someone who can already write to your home directory. As for the symlink:
+  reads do follow one — point `state.json` at a file holding valid JSON and
+  its contents are read as state — but planting that link needs write access
+  to a directory that is now 0700, which is not a boundary anyone crosses
+  without already owning the account. The write side is genuinely safe: the
+  quarantine renames the link rather than the file it points at, and a state
+  write replaces the link with a real file, so the target is never truncated
+  or overwritten.*
+
 ## 1.16.3 — 2026-08-22
 
 - **A dashboard left open overnight no longer runs the machine out of memory.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unsnooze",
-  "version": "1.16.3",
+  "version": "1.17.0",
   "description": "Automatically resume Claude Code, Codex CLI, Grok, Qwen Code, Kimi CLI, OpenCode, and Antigravity sessions when 5-hour or weekly usage limits reset—on macOS, Linux and Windows, with or without a terminal multiplexer.",
   "keywords": [
     "claude",

--- a/src/agents/kimi.js
+++ b/src/agents/kimi.js
@@ -54,7 +54,15 @@ function sessionsDirFor(cwd, kimiDir) {
   return join(kimiDir, 'sessions', createHash('md5').update(cwd).digest('hex'));
 }
 
+// sessionId comes from a hook payload and is used as a path component here.
+// The result only picks `-r <id>` over `--continue` and the id travels as
+// argv with no shell, so the exposure is an existence oracle rather than a
+// traversal — but it is the same shape as transcriptPath's, and the same
+// filename-shape gate closes it.
+const SAFE_SESSION_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
 function sessionExists(sessionId, kimiDir) {
+  if (!SAFE_SESSION_ID_RE.test(String(sessionId ?? ''))) return false;
   let hashes;
   try { hashes = readdirSync(join(kimiDir, 'sessions')); } catch { return false; }
   return hashes.some(h => existsSync(join(kimiDir, 'sessions', h, sessionId)));

--- a/src/askpass.js
+++ b/src/askpass.js
@@ -3,7 +3,8 @@
 // anywhere. The SERVICE/ACCOUNT/VAR *names* may appear on argv; the secret
 // itself never does — it only ever comes back on stdout/stdin.
 import { execFileSync, spawnSync } from 'node:child_process';
-import { writeFileSync, chmodSync, mkdirSync, renameSync } from 'node:fs';
+import { writeFileSync, chmodSync, renameSync } from 'node:fs';
+import { ensureStateDir } from './config.js';
 import { join } from 'node:path';
 
 export class AuthError extends Error {
@@ -163,7 +164,7 @@ export async function cmdAskpass(args = []) {
 // by Task 5) because ssh controls the helper's argv — it passes only the
 // prompt text, never the host.
 export function ensureAskpassHelper({ platform = process.platform, stateDir, nodePath = process.execPath, scriptPath }) {
-  mkdirSync(stateDir, { recursive: true });
+  ensureStateDir(stateDir);
   if (platform === 'win32') {
     // Native ssh.exe needs a real exe; unix-like win ssh (Git/WSL) accepts a script.
     // The resolution ladder (design §5c) is finalized in Task 7's cross-platform pass;

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,8 @@
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
+import {
+  mkdirSync, chmodSync, writeFileSync, renameSync, lstatSync, statSync, readdirSync,
+} from 'node:fs';
 
 function envInt(name, def) {
   const v = parseInt(process.env[name] ?? '', 10);
@@ -14,6 +17,172 @@ export const EVENTS_DIR = join(STATE_DIR, 'events');
 export const RESUMER_LOCK = join(STATE_DIR, 'resumer.lock');
 // High-frequency burn accumulator + warn-dedup (daemon single-writer).
 export const USAGE_FILE = join(STATE_DIR, 'usage.json');
+
+// Everything under STATE_DIR is owner-only. The directory holds an ntfy
+// bearer token (config.json), queued prompt text and cwd paths (state.json),
+// ssh destinations and credential-source commands (hosts.json) — none of it
+// another local user's business, and the dir mode is what protects the files
+// that don't set their own. mkdir's `mode` only applies when it creates, so
+// a 0755 dir left by a pre-1.17.0 install is repaired explicitly.
+// No-op on Windows (node's chmod only carries the read-only bit there); the
+// user profile ACL already restricts it.
+export function ensureStateDir(dir = STATE_DIR) {
+  // Creating a directory owner-only is always right — we are about to put a
+  // 0600 file in it.
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // Narrowing one that ALREADY exists is only ever done for our own state
+  // dir. ensureStateDir is also called with a caller-supplied path
+  // (writeUsageStore takes one), and re-permissioning someone else's
+  // directory — or the files inside it — is not this function's business.
+  if (isStateDir(dir)) {
+    try { chmodSync(dir, 0o700); } catch { /* shared/CI dir, not ours to fix */ }
+    repairModes(dir);
+  }
+  return dir;
+}
+
+// Repairing an install that predates 1.17.0. Three things the writers alone
+// cannot fix: mkdir's `mode` is ignored for a directory that already exists,
+// an append/open reuses an existing file's inode, and config.json/hosts.json
+// are written only by `config set` / `hosts add` — on an install that never
+// touches them again they would keep their old 0644 (and, for config.json,
+// the ntfy token in it) indefinitely. So the modes are repaired directly.
+//
+// Re-checked on an interval rather than once per process: daemon.log is
+// created by launchd/systemd redirecting the daemon's stdout, so it can
+// appear at 0644 AFTER a pass has run — in a process that then lives for
+// days. A walk is a readdir and a handful of lstats, so this is free at
+// daemon cadence.
+const MODE_REPAIR_INTERVAL_MS = envInt('UNSNOOZE_MODE_REPAIR_MS', 60_000);
+const repairedAt = new Map();
+
+// Compare resolved paths, not raw strings: callers reach ensureStateDir
+// through dirname(join(STATE_DIR, 'config.json')), which normalizes away a
+// trailing slash that STATE_DIR itself may carry from UNSNOOZE_STATE_DIR. A
+// raw comparison silently answers "not our directory" and skips the repair.
+const isStateDir = (dir) => resolve(dir) === resolve(STATE_DIR);
+
+// ONE walk, exported so `unsnooze doctor` reports from exactly what the
+// automatic repair acts on. They were separate before, and drifted: the
+// repair worked from a fixed list of filenames while doctor walked the whole
+// directory, so a quarantined state.json or a crashed writer's tmp file — the
+// two leftovers that hold verbatim copies of the sensitive files — were
+// reported forever and never fixed.
+//
+// Top level plus one level down is the entire layout: a handful of files and
+// four flat subdirectories.
+export function scanStateDir(dir = STATE_DIR, { platform = process.platform } = {}) {
+  const out = [];
+  // Windows has no POSIX mode bits. libuv synthesises them by mirroring the
+  // owner bits into group and other (win/fs.c `fs__stat_impl`), so a file is
+  // always 0666 (0444 read-only) and a directory 0777 — `mode & 0o077` is
+  // never zero and EVERY entry would look permanently exposed. Meanwhile
+  // uv_fs_chmod only toggles FILE_ATTRIBUTE_READONLY, so no repair could ever
+  // clear it: doctor would never report healthy, `--fix` would claim success
+  // while changing nothing, and the daemon would re-chmod the whole directory
+  // every interval forever. Access there is governed by the profile ACL.
+  if (platform === 'win32') return out;
+  // The root is stat'd, not lstat'd: a state dir that is itself a symlink is
+  // a legitimate setup (dotfiles, another volume) and must still be checked
+  // and repaired. Entries INSIDE are lstat'd and a link is skipped — chmod
+  // follows links, and following one there would reach outside the dir.
+  const inspect = (path, rel, isRoot = false) => {
+    try {
+      const st = isRoot ? statSync(path) : lstatSync(path);
+      if (!isRoot && st.isSymbolicLink()) return null;
+      const linked = !isRoot && !st.isDirectory() && st.nlink > 1;
+      // Strip group/other, but never the owner's execute bit: the state dir
+      // holds executables (askpass.sh, and whatever a test or a user drops
+      // beside it), and forcing a flat 0600 turns those into EACCES on spawn.
+      // Directories need their own traverse bit, hence 0700 rather than 0600.
+      const want = st.isDirectory() ? 0o700 : (0o600 | (st.mode & 0o100));
+      if ((st.mode & 0o077) !== 0) {
+        // `skipRepair` for a hardlink: lstat cannot distinguish one, so chmod
+        // would change an inode that also lives outside this directory.
+        // Reported anyway — an exposed file the repair will not touch is
+        // exactly what the doctor finding exists to surface.
+        out.push({ path, rel, mode: st.mode & 0o777, want, skipRepair: linked });
+      }
+      return st;
+    } catch { return null; }
+  };
+  if (!inspect(dir, '.', true)) return out;
+  let names = [];
+  try { names = readdirSync(dir); } catch { return out; }
+  for (const name of names) {
+    const path = join(dir, name);
+    const st = inspect(path, name);
+    if (!st?.isDirectory()) continue;
+    try {
+      for (const child of readdirSync(path)) inspect(join(path, child), `${name}/${child}`);
+    } catch { /* unreadable */ }
+  }
+  return out;
+}
+
+// Applies what scanStateDir found. `want` carries 0700 for directories and
+// 0600 for files — a directory chmod'd 0600 would lose its traverse bit and
+// nothing inside it could be opened.
+// Returns { fixed, refused, ineffective }. The three outcomes are genuinely
+// different and the caller needs to tell them apart:
+//   fixed       — the bits moved.
+//   refused     — chmod threw (EPERM, EROFS, an immutable flag). A real
+//                 exposure that cannot be repaired; keep reporting it.
+//   ineffective — chmod SUCCEEDED and nothing changed. The filesystem does
+//                 not implement POSIX modes at all (a CIFS/vfat/NTFS mount
+//                 with `noperm`, WSL's drvfs, a Docker bind mount from a
+//                 Windows host). Retrying forever would never converge, and
+//                 `process.platform` does not identify this case — only
+//                 attempting it does.
+export function narrowStateDir(entries) {
+  let fixed = 0, refused = 0, ineffective = 0;
+  for (const e of entries) {
+    if (e.skipRepair) continue;
+    try {
+      chmodSync(e.path, e.want);
+      if ((lstatSync(e.path).mode & 0o077) === 0) fixed += 1;
+      else ineffective += 1;
+    } catch { refused += 1; }
+  }
+  return { fixed, refused, ineffective };
+}
+
+// Directories whose filesystem provably ignores chmod. Learned by attempting
+// it, never guessed from the platform.
+const modesUnenforced = new Set();
+
+function repairModes(dir) {
+  // Key on the resolved path: callers reach this through
+  // dirname(join(STATE_DIR, 'x')), which normalizes a trailing slash away, so
+  // raw strings would give the same directory two throttle slots.
+  const key = resolve(dir);
+  if (modesUnenforced.has(key)) return;
+  const now = Date.now();
+  if (now - (repairedAt.get(key) ?? -Infinity) < MODE_REPAIR_INTERVAL_MS) return;
+  repairedAt.set(key, now);
+  const entries = scanStateDir(dir);
+  if (entries.length === 0) return;
+  const { fixed, refused, ineffective } = narrowStateDir(entries);
+  // Every attempt succeeded and not one bit moved: this filesystem has no
+  // POSIX modes to set. Stop walking it — the alternative is re-chmodding
+  // the whole directory every interval for the life of the daemon.
+  if (fixed === 0 && refused === 0 && ineffective > 0) modesUnenforced.add(key);
+}
+
+// tmp + rename + chmod. writeFileSync's `mode` lands only when it CREATES the
+// file, so a tmp left behind by a crashed predecessor that happened to share
+// this pid would otherwise carry its own 0644 onto the target through the
+// rename — and a target left 0644 by an older version would never be fixed.
+// The chmod after the rename closes both. Same pattern, and the same reason,
+// as ensureAskpassHelper in askpass.js.
+export function writePrivateFile(target, tmp, data) {
+  writeFileSync(tmp, data, { mode: 0o600 });
+  renameSync(tmp, target);
+  // A filesystem with no usable chmod (FAT, some network mounts) must not
+  // turn every state write into a crash — the 0700 directory still covers it.
+  try { chmodSync(target, 0o600); } catch { /* best-effort */ }
+  return target;
+}
 
 export const CLAUDE_DIR = process.env.UNSNOOZE_CLAUDE_DIR
   || process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -10,7 +10,7 @@ import { readFileSync, readdirSync, renameSync, existsSync, unlinkSync, lstatSyn
 import { spawnSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
-import { CLAUDE_SETTINGS, RESUMER_LOCK } from './config.js';
+import { CLAUDE_SETTINGS, RESUMER_LOCK, STATE_DIR, scanStateDir, narrowStateDir } from './config.js';
 import { getMultiplexer } from './multiplexer.js';
 import { makeLogger } from './logger.js';
 import { shouldUseTui, formatDoctorTui } from './tui.js';
@@ -151,6 +151,17 @@ function daemonRunning() {
  * detail, fix? } — `fix` is a machine-actionable descriptor consumed by
  * applyFixes. healthy === no legacy and no health findings.
  */
+// Both delegate to config.js's walk: the reporter and the automatic repair
+// must never disagree about what counts as exposed, which is exactly what
+// happened when each had its own idea of where to look.
+export function findExposedStateFiles(dir = STATE_DIR, opts = {}) {
+  return scanStateDir(dir, opts).map(e => ({ ...e, mode: e.mode.toString(8) }));
+}
+
+export function narrowStateModes(entries) {
+  return narrowStateDir(entries);
+}
+
 export async function runDoctor({
   runner = defaultRunner,
   platform = process.platform,
@@ -164,6 +175,7 @@ export async function runDoctor({
   rcContent = undefined,
   profileContent = undefined,
   autostartDir = null,
+  stateDir = STATE_DIR,
 } = {}) {
   const findings = [];
 
@@ -220,6 +232,22 @@ export async function runDoctor({
       detail: '  run: unsnooze install --yes  (then: exec $SHELL)',
     });
   }
+  // The state dir is repaired on every write, but chmod is swallowed there —
+  // a filesystem that cannot honour it (FAT, some network mounts) would
+  // otherwise leave everything world-readable with nothing ever saying so.
+  // This is the place that says so, and --fix retries the chmod.
+  const exposed = findExposedStateFiles(stateDir, { platform });
+  if (exposed.length) {
+    findings.push({
+      id: 'state-permissions', kind: 'health',
+      title: `${exposed.length} file(s) in ${stateDir} are readable by other users`,
+      detail: exposed.slice(0, 8).map(e => `  ${e.mode} ${e.rel}`).join('\n')
+        + (exposed.length > 8 ? `\n  …and ${exposed.length - 8} more` : '')
+        + '\n  run: unsnooze doctor --fix',
+      fix: { action: 'narrow-state-modes', entries: exposed },
+    });
+  }
+
   let muxOk = false;
   try { muxOk = !!mux.available(); } catch { muxOk = false; }
   if (!muxOk) {
@@ -321,6 +349,11 @@ export async function applyFixes(report, {
       } else {
         actions.push({ action: 'error', detail: 'could not determine a PATH that finds the multiplexer — run `unsnooze install --daemon` from your shell' });
       }
+    } else if (fix.action === 'narrow-state-modes') {
+      const r = narrowStateModes(fix.entries || []);
+      actions.push({ action: 'narrowed-modes', ...r });
+      log(`doctor: narrowed ${r.fixed} state-dir path(s) to owner-only `
+        + `(${r.refused} refused, ${r.ineffective} ignored by the filesystem)`);
     } else if (fix.action === 'archive-dir') {
       let target = `${fix.dir}.bak`;
       if (existsSync(target)) target = `${fix.dir}.bak.${now}`;
@@ -379,6 +412,16 @@ export async function cmdDoctor(rest = [], deps = {}) {
       if (a.action === 'killed') print(`  ✓ stopped csg process ${a.pid}`);
       else if (a.action === 'removed-unit') print(`  ✓ removed ${a.unit}`);
       else if (a.action === 'archived') print(`  ✓ archived ${a.from} → ${a.to}`);
+      else if (a.action === 'narrowed-modes') {
+        if (a.fixed) print(`  ✓ made ${a.fixed} state-dir path(s) owner-only`);
+        // Distinguish "cannot" from "did not": a filesystem with no POSIX
+        // modes reports success and changes nothing, and telling the user to
+        // try again would be advice that can never work.
+        if (a.ineffective) {
+          print(`  · ${a.ineffective} path(s) unchanged — this filesystem does not enforce POSIX permissions`);
+        }
+        if (a.refused) print(`  ✗ ${a.refused} path(s) could not be changed (permission denied)`);
+      }
       else if (a.action === 'error') print(`  ! ${a.detail}`);
     }
     const pkg = legacy.find(f => f.id === 'csg-package');
@@ -386,8 +429,14 @@ export async function cmdDoctor(rest = [], deps = {}) {
     return 0;
   }
 
+  // Offer --fix whenever anything reported is actually machine-fixable, not
+  // only for csg leftovers: a health finding that carries a `fix` (state
+  // permissions) was otherwise a dead end for the reader.
+  const fixable = report.findings.some(f => f.fix);
   print(legacy.length
     ? '\nRun `unsnooze doctor --fix` to stop csg processes, remove its autostart, and archive its state.'
-    : '\nSee the hints above to finish the install.');
+    : fixable
+      ? '\nRun `unsnooze doctor --fix` to apply the repairs above.'
+      : '\nSee the hints above to finish the install.');
   return 1;
 }

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -158,6 +158,15 @@ export function findExposedStateFiles(dir = STATE_DIR, opts = {}) {
   return scanStateDir(dir, opts).map(e => ({ ...e, mode: e.mode.toString(8) }));
 }
 
+// Deliberately NOT given runDoctor's `platform`. Every other check uses that
+// to simulate an install target — "what would doctor say on Windows?" — but
+// whether mode bits mean anything is a fact about the filesystem actually
+// under the process, not about the platform being simulated. Passing the
+// simulated one made a `platform: 'darwin'` test raise this finding while
+// running on a Windows runner, where the modes are synthetic and no repair
+// could ever clear it. scanStateDir keeps its own injectable platform for
+// direct unit tests.
+
 export function narrowStateModes(entries) {
   return narrowStateDir(entries);
 }
@@ -236,7 +245,7 @@ export async function runDoctor({
   // a filesystem that cannot honour it (FAT, some network mounts) would
   // otherwise leave everything world-readable with nothing ever saying so.
   // This is the place that says so, and --fix retries the chmod.
-  const exposed = findExposedStateFiles(stateDir, { platform });
+  const exposed = findExposedStateFiles(stateDir);
   if (exposed.length) {
     findings.push({
       id: 'state-permissions', kind: 'health',

--- a/src/fleet.js
+++ b/src/fleet.js
@@ -5,9 +5,9 @@
 // allowlisted host tokens, closed verb set, sentinel-framed JSON, and
 // control-char-stripped ingest.
 import { join } from 'node:path';
-import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync as fsExistsSync } from 'node:fs';
+import { readFileSync, existsSync as fsExistsSync } from 'node:fs';
 import { spawn, execFileSync, spawnSync } from 'node:child_process';
-import { STATE_DIR } from './config.js';
+import { STATE_DIR, ensureStateDir, writePrivateFile } from './config.js';
 import { colors, shouldUseTui, makeTable, logoBlock, badge } from './tui.js';
 import { ensureAskpassHelper, resolveSecret, readSecret } from './askpass.js';
 import { UNSNOOZE_BIN } from './spawn.js';
@@ -288,10 +288,12 @@ export function readHosts() {
 }
 
 export function writeHosts(hosts) {
-  mkdirSync(STATE_DIR, { recursive: true });
-  const tmp = HOSTS_FILE + `.tmp.${process.pid}`;
-  writeFileSync(tmp, JSON.stringify(hosts, null, 2) + '\n');
-  renameSync(tmp, HOSTS_FILE);
+  ensureStateDir();
+  // Owner-only: a `command` source's --cmd string is whatever the user
+  // pointed at their secret store, and a keychain source names the
+  // service/account to look up.
+  writePrivateFile(HOSTS_FILE, HOSTS_FILE + `.tmp.${process.pid}`,
+    JSON.stringify(hosts, null, 2) + '\n');
 }
 
 function parseFlags(argv) {
@@ -740,10 +742,11 @@ export function readFleetCache() {
 }
 
 export function writeFleetCache(results) {
-  mkdirSync(STATE_DIR, { recursive: true });
-  const tmp = FLEET_CACHE_FILE + `.tmp.${process.pid}`;
-  writeFileSync(tmp, JSON.stringify(results, null, 2) + '\n');
-  renameSync(tmp, FLEET_CACHE_FILE);
+  ensureStateDir();
+  // Owner-only: the cache mirrors every remote host's cwd paths and
+  // queued-prompt previews.
+  writePrivateFile(FLEET_CACHE_FILE, FLEET_CACHE_FILE + `.tmp.${process.pid}`,
+    JSON.stringify(results, null, 2) + '\n');
 }
 
 // I1: a `prompt`-source host at a real interactive TTY is the one case

--- a/src/hook.js
+++ b/src/hook.js
@@ -89,9 +89,10 @@ export async function runHook(rest = []) {
       // Seconds-scale problem — leave a marker for the pane's monitor, do NOT
       // record in state.json.
       if (pane) {
-        mkdirSync(EVENTS_DIR, { recursive: true });
+        mkdirSync(EVENTS_DIR, { recursive: true, mode: 0o700 });
         writeFileSync(join(EVENTS_DIR, `${addressHash({ mux: muxName, paneOwner, pane })}.json`),
-          JSON.stringify({ mux: muxName, paneOwner, pane, kind, at: Date.now(), payload: { error: payload.error ?? null } }));
+          JSON.stringify({ mux: muxName, paneOwner, pane, kind, at: Date.now(), payload: { error: payload.error ?? null } }),
+          { mode: 0o600 });
       }
       return 0;
     }

--- a/src/lease.js
+++ b/src/lease.js
@@ -43,10 +43,10 @@ function leasePath(address, leaseId) {
 }
 
 export function writeLease(lease) {
-  mkdirSync(LEASES_DIR, { recursive: true });
+  mkdirSync(LEASES_DIR, { recursive: true, mode: 0o700 });
   const path = leasePath(lease, lease.leaseId);
   const tmp = `${path}.tmp.${process.pid}.${randomUUID()}`;
-  writeFileSync(tmp, JSON.stringify(lease));
+  writeFileSync(tmp, JSON.stringify(lease), { mode: 0o600 });
   renameSync(tmp, path);
   return lease;
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,6 @@
-import { appendFileSync, mkdirSync, statSync, renameSync, copyFileSync, truncateSync } from 'node:fs';
+import { appendFileSync, statSync, renameSync, copyFileSync, truncateSync } from 'node:fs';
 import { dirname } from 'node:path';
-import { LOG_FILE } from './config.js';
+import { LOG_FILE, ensureStateDir } from './config.js';
 
 // Logs must never grow unbounded (a single upgrade-window crash-loop once
 // produced a 10.3 MB daemon.log). One rotated generation is kept: file → .1.
@@ -46,11 +46,13 @@ export function log(component, message) {
   const line = `${new Date().toISOString()} [${component}] ${message}\n`;
   try {
     if (!dirReady) {
-      mkdirSync(dirname(LOG_FILE), { recursive: true });
+      ensureStateDir(dirname(LOG_FILE));
       dirReady = true;
     }
     rotateIfLarge(LOG_FILE);
-    appendFileSync(LOG_FILE, line);
+    // mode applies only when append CREATES the file — an existing log keeps
+    // whatever it has, and the 0700 dir is what covers it either way.
+    appendFileSync(LOG_FILE, line, { mode: 0o600 });
   } catch {
     // Logging must never crash the hook or monitor paths.
   }

--- a/src/multiplexers/headless.js
+++ b/src/multiplexers/headless.js
@@ -96,9 +96,11 @@ export function createHeadless({
     // A revive is just a detached child. Its output goes to a per-session log
     // because there is no scrollback to read it out of later.
     async newWindow(sessionName, cwd, launchSpec) {
-      mkdirSync(logDir, { recursive: true });
+      // 0700/0600: this log is the entire stdout+stderr of an unattended
+      // agent run — the most revealing thing under the state dir.
+      mkdirSync(logDir, { recursive: true, mode: 0o700 });
       const logPath = join(logDir, `${sessionName}.log`);
-      const fd = openSync(logPath, 'a');
+      const fd = openSync(logPath, 'a', 0o600);
       const child = spawner(launchSpec.file, launchSpec.args || [], {
         cwd,
         detached: true,

--- a/src/mux-sessions.js
+++ b/src/mux-sessions.js
@@ -29,10 +29,10 @@ export function recordOwnedSession({ mux, name }) {
   if (!mux || !name) return null;
   const record = { mux, name, createdAt: Date.now(), pid: process.pid };
   try {
-    mkdirSync(SESSIONS_DIR(), { recursive: true });
+    mkdirSync(SESSIONS_DIR(), { recursive: true, mode: 0o700 });
     const path = recordPath(mux, name);
     const tmp = `${path}.tmp.${process.pid}.${randomUUID()}`;
-    writeFileSync(tmp, JSON.stringify(record));
+    writeFileSync(tmp, JSON.stringify(record), { mode: 0o600 });
     renameSync(tmp, path);
     return record;
   } catch {

--- a/src/resumer.js
+++ b/src/resumer.js
@@ -4,12 +4,12 @@
 // fires on the next tick), then re-opens/continues every due session.
 // Exits when no non-terminal records remain; the next limit event respawns it.
 
-import { writeFileSync, readFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { writeFileSync, readFileSync, unlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { getMultiplexer, backendCanType } from './multiplexer.js';
 import {
-  RESUMER_LOCK, STATE_DIR, POLL_INTERVAL_MS, STAGGER_MS, VERIFY_DELAY_MS,
+  RESUMER_LOCK, POLL_INTERVAL_MS, STAGGER_MS, VERIFY_DELAY_MS, ensureStateDir,
   BUSY_DEFER_MS, MAX_BUSY_DEFERS, MAX_RESUME_ATTEMPTS, READY_TIMEOUT_MS,
   CAPTURE_LINES, PANE_SCAN_LINES, RESUME_SESSION_NAME,
   RESET_MARGIN_MS, FALLBACK_RESET_MS, PROBE_INTERVAL_MS, PROBE_MAX_MS,
@@ -64,10 +64,10 @@ function defaultIsResumer(pid) {
 // read-check-write window. A held lock is honored only when its pid is alive
 // AND looks like a resumer; stale/garbage/recycled locks are replaced.
 export function acquireSingleton({ isResumer = defaultIsResumer } = {}) {
-  mkdirSync(STATE_DIR, { recursive: true });
+  ensureStateDir();
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      writeFileSync(RESUMER_LOCK, String(process.pid), { flag: 'wx' });
+      writeFileSync(RESUMER_LOCK, String(process.pid), { flag: 'wx', mode: 0o600 });
       return true;
     } catch { /* lock exists — inspect the holder below */ }
     let pid = NaN;

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -40,8 +40,26 @@ export function latestSessionId(cwd, aroundTs = null) {
   return best ? best.id : null;
 }
 
+// sessionId lands here straight off a hook payload / transcript record and is
+// used as a path component — the same untrusted-value-as-filename shape the
+// statusline shim had, on the channel everyone has enabled. dashCwd already
+// sanitizes the cwd half; a '/' or a '..' in the id half would walk this read
+// out of the projects tree.
+//
+// Deliberately a filename-shape check rather than UUID_RE: that regex is the
+// right gate for *discovering* transcripts (it reads Claude's own directory
+// listing) but the wrong one here, where the id arrives from an agent whose
+// naming we do not own. Requiring a uuid would silently turn off the context
+// guard for any session named otherwise; requiring a safe component closes
+// the traversal either way. '.' and '..' are harmless: the '.jsonl' suffix
+// makes them ordinary filenames. Returns null for anything else, which every
+// caller already reports as "no transcript".
+const SAFE_SESSION_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
 export function transcriptPath(cwd, sessionId, { claudeDir = CLAUDE_DIR } = {}) {
-  return join(claudeDir, 'projects', dashCwd(cwd), `${sessionId}.jsonl`);
+  const id = String(sessionId ?? '');
+  if (!SAFE_SESSION_ID_RE.test(id)) return null;
+  return join(claudeDir, 'projects', dashCwd(cwd), `${id}.jsonl`);
 }
 
 export function claudeRecordEnv(env = process.env) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -6,9 +6,9 @@
 // the global resumeMessage even when the global came from an env var (see
 // resolveResumeMessage).
 
-import { readFileSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { MUX_NAMES, STATE_DIR } from './config.js';
+import { MUX_NAMES, STATE_DIR, ensureStateDir, writePrivateFile } from './config.js';
 
 export const CONFIG_FILE = () => join(process.env.UNSNOOZE_STATE_DIR || STATE_DIR, 'config.json');
 
@@ -267,10 +267,11 @@ export function setConfigValue(key, rawValue) {
 
 export function writeConfig(config) {
   const path = CONFIG_FILE();
-  mkdirSync(dirname(path), { recursive: true });
-  const tmp = join(dirname(path), `.config.tmp.${process.pid}`);
-  writeFileSync(tmp, JSON.stringify(config, null, 2) + '\n');
-  renameSync(tmp, path);
+  ensureStateDir(dirname(path));
+  // Owner-only: ntfyToken is a Bearer credential, and config.json was
+  // world-readable before 1.17.0.
+  writePrivateFile(path, join(dirname(path), `.config.tmp.${process.pid}`),
+    JSON.stringify(config, null, 2) + '\n');
 }
 
 export function configFileExists() {

--- a/src/state.js
+++ b/src/state.js
@@ -10,7 +10,8 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import {
-  STATE_DIR, STATE_FILE, LOCK_DIR, STALE_LOCK_MS, PRUNE_AFTER_MS,
+  STATE_DIR, STATE_FILE, LOCK_DIR, STALE_LOCK_MS, PRUNE_AFTER_MS, ensureStateDir,
+  writePrivateFile,
   DEDUPE_WINDOW_MS, STALE_AFTER_MS, PROBE_INTERVAL_MS, PROBE_MAX_MS,
   RESET_MARGIN_MS,
 } from './config.js';
@@ -48,22 +49,78 @@ function lockHolderAlive() {
   }
 }
 
+// lockHolderAlive() can only ask "is this pid alive", never "is it still
+// unsnooze". A leaked lock whose pid is later recycled onto some unrelated
+// long-lived process therefore looks live forever, and every writer — daemon,
+// CLI, in-agent hook — wedges permanently with no way out but deleting the
+// directory by hand. Past this ceiling, age wins regardless.
+//
+// This is a deliberate trade, not a free win: stealing from a holder that IS
+// still working puts two writers in the critical section, and the robbed one's
+// rename then clobbers the thief's write — a lost update. It is chosen because
+// a permanent unrecoverable wedge is the worse failure. The exposure is kept
+// small by holding this lock only for in-memory work plus one write:
+// upsertSession's git call is hoisted out for exactly this reason. Five
+// minutes is ~200x the worst measured critical section.
+//
+// Known limit: both sides of the age are wall-clock, so a forward clock step
+// (VM resume, laptop wake, a large NTP correction) can age a fresh lock past
+// the ceiling at once. There is no cross-process monotonic clock to use
+// instead, which is part of why the ceiling is generous rather than tight.
+const HARD_STALE_LOCK_MS = Math.max(STALE_LOCK_MS * 30, 300_000);
+
 function acquireLock() {
   const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  let parentRepaired = false;
   for (;;) {
     try {
-      mkdirSync(LOCK_DIR);
+      mkdirSync(LOCK_DIR, { mode: 0o700 });
       // Record the holder so a slow-but-alive writer is never robbed — age
       // alone can't tell a hung process from a busy one.
-      try { writeFileSync(join(LOCK_DIR, 'pid'), String(process.pid)); } catch { /* best-effort */ }
+      try { writeFileSync(join(LOCK_DIR, 'pid'), String(process.pid), { mode: 0o600 }); } catch { /* best-effort */ }
       return;
     } catch (err) {
-      if (err.code !== 'EEXIST') { mkdirSync(STATE_DIR, { recursive: true }); continue; }
+      if (err.code !== 'EEXIST') {
+        // NOT contention. A missing STATE_DIR is worth exactly one immediate
+        // repair-and-retry; every other errno (EACCES on an unwritable
+        // ~/.unsnooze, EROFS, ENOSPC) must fall through to the same backoff
+        // and deadline as any other failure. This branch used to `continue`
+        // unconditionally, skipping both — and since mkdir -p on an existing
+        // STATE_DIR succeeds as a no-op, an unwritable state dir spun here
+        // forever at ~70% of a core, ignoring LOCK_TIMEOUT_MS, in every writer:
+        // the daemon, the CLI, and the StopFailure hook inside the agent.
+        if (!parentRepaired) {
+          parentRepaired = true;
+          try { ensureStateDir(); } catch { /* fall through to the backoff */ }
+          continue;
+        }
+        if (Date.now() > deadline) {
+          throw new Error(`unsnooze: cannot create state lock at ${LOCK_DIR}: ${err.code || err.message}`);
+        }
+        sleepSync(50);
+        // A *recurring* ENOENT means the directory keeps going away under us
+        // (an uninstall racing a write), not that the one-shot repair failed.
+        // Keep repairing it, but from the backoff — never in a tight loop.
+        if (err.code === 'ENOENT') { try { ensureStateDir(); } catch { /* next pass */ } }
+        continue;
+      }
       try {
-        const age = Date.now() - statSync(LOCK_DIR).mtimeMs;
-        if (age > STALE_LOCK_MS && lockHolderAlive() !== true) {
-          rmSync(LOCK_DIR, { recursive: true, force: true });   // steal from a dead/unknown holder
-          log(`stole stale lock (age ${Math.round(age)}ms)`);
+        const before = statSync(LOCK_DIR);
+        const age = Date.now() - before.mtimeMs;
+        if (age > STALE_LOCK_MS && (age > HARD_STALE_LOCK_MS || lockHolderAlive() !== true)) {
+          // Re-stat immediately before removing. The staleness verdict above
+          // costs a readFileSync + kill(), and in that gap another contender
+          // can have stolen this same lock and created a fresh one — removing
+          // that would drop a live holder's lock and break mutual exclusion.
+          // A matching inode means it is still the dir we judged stale. This
+          // narrows the window rather than closing it: a filesystem that
+          // recycles a just-freed directory inode can hand the same number
+          // back, and Windows may report 0 for both — in either case this
+          // degrades to the old unconditional behaviour, never to a worse one.
+          if (statSync(LOCK_DIR).ino === before.ino) {
+            rmSync(LOCK_DIR, { recursive: true, force: true });   // steal from a dead/unknown holder
+            log(`stole stale lock (age ${Math.round(age)}ms)`);
+          }
           continue;
         }
       } catch { /* lock vanished between check and stat — retry */ }
@@ -74,6 +131,14 @@ function acquireLock() {
 }
 
 function releaseLock() {
+  try {
+    // Only drop a lock we still hold. A stale-lock steal can rob a live
+    // holder (see acquireLock); if that happened, the dir now belongs to the
+    // thief, and removing it would hand a third writer a lock the thief still
+    // believes is theirs. An unreadable/absent pid file means the lock is
+    // ours-but-unstamped or already gone — both fall through to the remove.
+    if (readFileSync(join(LOCK_DIR, 'pid'), 'utf-8') !== String(process.pid)) return;
+  } catch { /* no pid file: our own best-effort stamp failed, or it's gone */ }
   try { rmSync(LOCK_DIR, { recursive: true, force: true }); } catch { /* already gone */ }
 }
 
@@ -86,7 +151,12 @@ export function readState() {
     try {
       const quarantine = `${STATE_FILE}.corrupt.${Date.now()}`;
       renameSync(STATE_FILE, quarantine);
-      log(`CORRUPT state.json quarantined to ${quarantine}: ${err.message}`);
+      // err.message, NOT logged: V8 embeds the first bytes of the input in
+      // its JSON.parse message ("Unexpected token 'S', \"SUPER SECR\"..."),
+      // so a state.json that is really a symlink to something else would
+      // print that file's opening bytes into unsnooze.log. The quarantined
+      // file is right there on disk for anyone who needs to see the content.
+      log(`CORRUPT state.json quarantined to ${quarantine} (${err.name || 'parse error'})`);
     } catch { /* someone else quarantined it first */ }
     return EMPTY();
   }
@@ -137,14 +207,14 @@ function normalizeRecord(rec) {
 // Locked read-modify-write. mutator receives the state object and mutates it
 // (or returns a replacement). Returns the final state.
 export function updateState(mutator) {
-  mkdirSync(STATE_DIR, { recursive: true });
+  ensureStateDir();
   acquireLock();
   try {
     const state = readState();
     const result = mutator(state) ?? state;
-    const tmp = join(STATE_DIR, `.state.tmp.${process.pid}`);
-    writeFileSync(tmp, JSON.stringify(result, null, 2));
-    renameSync(tmp, STATE_FILE);
+    // Owner-only: session records embed cwd paths and queued prompt text.
+    writePrivateFile(STATE_FILE, join(STATE_DIR, `.state.tmp.${process.pid}`),
+      JSON.stringify(result, null, 2));
     return result;
   } finally {
     releaseLock();
@@ -159,6 +229,24 @@ export function updateState(mutator) {
 // calibration snapshots so stop + ceiling sample never race (1.13).
 export function upsertSession(record, { after = null } = {}) {
   record = normalizeRecord({ ...record });
+  // Computed BEFORE the lock, never inside the mutator. workspaceFingerprint
+  // shells out to git, and execFileSync's `timeout` is a soft bound — it
+  // sends SIGTERM at the deadline and then waits for the child to actually
+  // exit, which a git wedged in uninterruptible I/O on a hung network mount
+  // never does. That made it the one unbounded operation under the state
+  // lock, and the only way a critical section could outlive
+  // HARD_STALE_LOCK_MS and be stolen from a writer that is still working.
+  // The cost of hoisting is one extra git call when the record turns out to
+  // be a duplicate; the benefit is that the lock is only ever held for
+  // in-memory work plus one write.
+  // 'resuming' is included deliberately: the `closing` branch inside the
+  // mutator can flip such a record to 'stopped', and the apply site below
+  // would then want a baseline this precompute never made. No caller passes
+  // 'resuming' today — this keeps the hoist from becoming a trap for one that
+  // later does.
+  const needsFingerprint = ['stopped', 'resuming'].includes(record.status)
+    && record.workspace === undefined;
+  const fingerprint = needsFingerprint ? workspaceFingerprint(record.cwd) : undefined;
   return updateState(state => {
     prune(state);
     const closing = state.paneClosures.find(c => c.pane && c.leaseId
@@ -228,9 +316,12 @@ export function upsertSession(record, { after = null } = {}) {
       log(`merged duplicate detection for pane ${record.pane} into ${existingKey}`);
     } else {
       // Baseline for the stale-workspace guard, captured once at stop time.
-      // (Merged duplicates above keep the ORIGINAL baseline — spread semantics.)
+      // (Merged duplicates above keep the ORIGINAL baseline — spread
+      // semantics — so this is applied on the non-duplicate branch ONLY.
+      // Assigning it before the branch would let the merge spread it over the
+      // existing record's baseline and silently reset it.)
       if (record.status === 'stopped' && record.workspace === undefined) {
-        record.workspace = workspaceFingerprint(record.cwd);
+        record.workspace = fingerprint;
       }
       const key = record.sessionId || `pane:${addressHash(record)}:${record.detectedAt}`;
       applied = { ...record, key };

--- a/src/update-check.js
+++ b/src/update-check.js
@@ -7,13 +7,14 @@
 // All of it is gated on the `updateCheck` setting / UNSNOOZE_UPDATE_CHECK.
 // The check is a plain GET to registry.npmjs.org — nothing identifying.
 
-import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getConfig } from './settings.js';
 import { notify } from './notify.js';
 import { UNSNOOZE_BIN, pidAlive } from './spawn.js';
+import { ensureStateDir, writePrivateFile } from './config.js';
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 export const PKG_VERSION = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8')).version;
@@ -31,10 +32,11 @@ export function readCache() {
 export function writeCache(patch) {
   const merged = { ...readCache(), ...patch };
   const path = CACHE_FILE();
-  mkdirSync(dirname(path), { recursive: true });
-  const tmp = join(dirname(path), `.update-check.tmp.${process.pid}`);
-  writeFileSync(tmp, JSON.stringify(merged, null, 2) + '\n');
-  renameSync(tmp, path);
+  // _update-check runs as a detached child, so on a fresh install this can be
+  // the process that creates ~/.unsnooze — it must create it owner-only.
+  ensureStateDir(dirname(path));
+  writePrivateFile(path, join(dirname(path), `.update-check.tmp.${process.pid}`),
+    JSON.stringify(merged, null, 2) + '\n');
   return merged;
 }
 

--- a/src/usage.js
+++ b/src/usage.js
@@ -11,7 +11,7 @@ import {
   CLAUDE_DIR, CODEX_DIR, USAGE_FILE, USAGE_ETA_WARN_MIN,
   USAGE_BURN_LOOKBACK_MS, USAGE_BURN_MIN_COVERAGE_MS, USAGE_IDLE_GAP_MS,
   USAGE_WINDOW_IDLE_MS, USAGE_CALIBRATION_RING, USAGE_CALIBRATION_MEDIAN_N,
-  USAGE_STATUSLINE_DIR,
+  USAGE_STATUSLINE_DIR, ensureStateDir, writePrivateFile,
 } from './config.js';
 import { readState, updateState } from './state.js';
 import { getConfig } from './settings.js';
@@ -535,10 +535,9 @@ export function readUsageStore(path = USAGE_FILE) {
 }
 
 export function writeUsageStore(store, path = USAGE_FILE) {
-  mkdirSync(dirname(path), { recursive: true });
-  const tmp = join(dirname(path), `.usage.tmp.${process.pid}`);
-  writeFileSync(tmp, JSON.stringify(store));
-  renameSync(tmp, path);
+  ensureStateDir(dirname(path));
+  writePrivateFile(path, join(dirname(path), `.usage.tmp.${process.pid}`),
+    JSON.stringify(store));
   return store;
 }
 
@@ -1239,15 +1238,30 @@ let data = {};
 try { data = JSON.parse(raw || '{}'); } catch { /* ignore */ }
 
 const dir = path.join(os.homedir(), '.claude', 'unsnooze');
-try { fs.mkdirSync(dir, { recursive: true }); } catch { /* ignore */ }
-const sid = data.session_id || data.sessionId || 'unknown';
+// 0700/0600 like the state dir: these drops carry your live rate-limit
+// numbers, and the shim is the only thing that creates them. mkdir's mode is
+// ignored for a directory that already exists, so an install that predates
+// this is repaired explicitly — the same reasoning ensureStateDir applies one
+// directory over. Skipped on Windows, where the POSIX bits are synthetic.
+try { fs.mkdirSync(dir, { recursive: true, mode: 0o700 }); } catch { /* ignore */ }
+if (process.platform !== 'win32') {
+  try { fs.chmodSync(dir, 0o700); } catch { /* not ours */ }
+}
+// The id becomes a filename. Claude Code sends a uuid, but nothing here is
+// in a position to trust that: a '/' or a '..' would walk the drop file out
+// of ~/.claude/unsnooze and overwrite any .json the user can write.
+const rawSid = String(data.session_id || data.sessionId || 'unknown');
+const sid = /^[A-Za-z0-9._-]{1,128}$/.test(rawSid) ? rawSid : 'unknown';
 const drop = path.join(dir, 'usage-' + sid + '.json');
 try {
   fs.writeFileSync(drop, JSON.stringify({
     rate_limits: data.rate_limits || null,
     at: Date.now(),
     sessionId: sid,
-  }));
+  }), { mode: 0o600 });
+  // mode only lands when writeFileSync CREATES the file; an existing drop
+  // from before this change keeps its own until chmod'd.
+  if (process.platform !== 'win32') fs.chmodSync(drop, 0o600);
 } catch { /* ignore */ }
 
 const orig = process.env.UNSNOOZE_STATUSLINE_ORIG || '';

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -293,9 +293,9 @@ export function createWatcher({
     }
     if (!dirty) return;
     try {
-      mkdirSync(dirname(offsetsPath), { recursive: true });
+      mkdirSync(dirname(offsetsPath), { recursive: true, mode: 0o700 });
       const tmp = join(dirname(offsetsPath), `.offsets.tmp.${process.pid}`);
-      writeFileSync(tmp, JSON.stringify(offsets));
+      writeFileSync(tmp, JSON.stringify(offsets), { mode: 0o600 });
       renameSync(tmp, offsetsPath);
       dirty = false;
     } catch (err) {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -1,5 +1,17 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// loadStatusSnapshot reaches readState(), which QUARANTINES a state.json it
+// cannot parse — renaming it out of the way. Unpinned, that ran against the
+// developer's real ~/.unsnooze and could have moved their live state file.
+// Must be set before the module graph freezes STATE_DIR.
+const STATE_DIR = mkdtempSync(join(tmpdir(), 'unsnooze-dashboard-test-'));
+process.env.UNSNOOZE_STATE_DIR = STATE_DIR;
+process.on('exit', () => rmSync(STATE_DIR, { recursive: true, force: true }));
+
 import { logoContainsBrand } from '../src/dashboard/Logo.js';
 import { shouldUseDashboard } from '../src/dashboard/run.js';
 import {

--- a/test/multiplexer-herdr.test.js
+++ b/test/multiplexer-herdr.test.js
@@ -1,7 +1,17 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import { createHerdr, SUBMIT_DELAY_MS } from '../src/multiplexers/herdr.js';
+// herdr's newSession calls recordOwnedSession, which writes into
+// STATE_DIR/mux-sessions — the real ~/.unsnooze unless this is set BEFORE the
+// module graph is imported. Must stay above the createHerdr import.
+const STATE_DIR = mkdtempSync(join(tmpdir(), 'unsnooze-herdr-test-'));
+process.env.UNSNOOZE_STATE_DIR = STATE_DIR;
+process.on('exit', () => rmSync(STATE_DIR, { recursive: true, force: true }));
+
+const { createHerdr, SUBMIT_DELAY_MS } = await import('../src/multiplexers/herdr.js');
 
 function fakeSpawner(respond = () => '') {
   const calls = [];

--- a/test/state-hardening.test.js
+++ b/test/state-hardening.test.js
@@ -1,0 +1,797 @@
+// Regression tests for the 1.17.0 hardening pass (issue #17 verification).
+//
+// Most cases pin a behaviour that was wrong before: the lock loop spinning
+// forever on an unwritable state dir, releaseLock dropping a lock it no
+// longer owned, the corrupt-state log echoing the file's own bytes, and
+// everything under ~/.unsnooze being world-readable.
+//
+// A few deliberately do NOT fail against the old code, and say so in place:
+// they guard the new behaviour against over-correction (a releaseLock that
+// refuses to release, a staleness ceiling that steals live locks, a repair
+// that reaches outside the state dir) or characterise a property the code
+// has always had.
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync, rmSync, statSync, lstatSync, chmodSync, mkdirSync, writeFileSync,
+  readFileSync, existsSync, symlinkSync, linkSync, utimesSync, readdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const DIR = mkdtempSync(join(tmpdir(), 'unsnooze-harden-'));
+process.env.UNSNOOZE_STATE_DIR = DIR;
+
+const { updateState, readState, upsertSession } = await import('../src/state.js');
+const { ensureStateDir } = await import('../src/config.js');
+
+after(() => {
+  try { chmodSync(DIR, 0o700); } catch { /* already writable */ }
+  rmSync(DIR, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+});
+
+const mode = p => statSync(p).mode & 0o777;
+
+// Everything under `dir` that any other local user could read, one level deep.
+function tooOpenUnder(dir) {
+  const out = [];
+  const visit = (p, rel) => {
+    const st = statSync(p);
+    if ((st.mode & 0o077) !== 0) out.push(`${(st.mode & 0o777).toString(8)} ${rel}`);
+    if (st.isDirectory()) for (const n of readdirSync(p)) visit(join(p, n), `${rel}/${n}`);
+  };
+  visit(dir, '.');
+  return out;
+}
+// chmod is a no-op on Windows (node only carries the read-only bit there),
+// so the permission expectations are POSIX-only.
+const posix = process.platform !== 'win32';
+
+test('ensureStateDir creates the state dir owner-only', { skip: !posix }, () => {
+  const d = join(DIR, 'fresh-dir');
+  ensureStateDir(d);
+  assert.equal(mode(d), 0o700);
+});
+
+test('ensureStateDir repairs a pre-existing world-readable state dir', { skip: !posix }, () => {
+  // Repair applies to OUR state dir specifically — see the foreign-directory
+  // test below for the other half of that rule.
+  chmodSync(DIR, 0o755);
+  assert.equal(mode(DIR), 0o755, 'precondition: the 0755 an older version left');
+  ensureStateDir();
+  assert.equal(mode(DIR), 0o700);
+});
+
+test('state.json is written owner-only', { skip: !posix }, () => {
+  updateState(s => { s.sessions.perm = { key: 'perm' }; return s; });
+  assert.equal(mode(join(DIR, 'state.json')), 0o600);
+  assert.equal(mode(DIR), 0o700, 'the state dir itself must be owner-only too');
+});
+
+test('a state.json rewrite repairs a pre-existing 0644 file', { skip: !posix }, () => {
+  const f = join(DIR, 'state.json');
+  chmodSync(f, 0o644);
+  updateState(s => { s.sessions.perm2 = { key: 'perm2' }; return s; });
+  assert.equal(mode(f), 0o600, 'tmp+rename must carry 0600 over the old file');
+});
+
+test('corrupt state.json is quarantined without echoing its bytes into the log', () => {
+  const f = join(DIR, 'state.json');
+  // V8 truncates the echoed input to TEN characters, so the probe has to fit
+  // inside that budget — a longer secret would never appear in the message
+  // even on the leaky code, and the assertion would prove nothing.
+  const probe = 'SUPRSECRET';
+  assert.equal(probe.length, 10);
+  writeFileSync(f, `${probe}_and_more, definitely not json`);
+  const state = readState();
+  assert.deepEqual(state.sessions, {}, 'corrupt file still starts a fresh state');
+
+  const logText = readFileSync(join(DIR, 'unsnooze.log'), 'utf-8');
+  const corruptLines = logText.split('\n').filter(l => l.includes('CORRUPT state.json'));
+  assert.ok(corruptLines.length > 0, 'the quarantine must still be logged loudly');
+  const last = corruptLines[corruptLines.length - 1];
+  assert.ok(!last.includes(probe),
+    `V8 embeds the parsed input in its JSON.parse message; it must not reach the log: ${last}`);
+  assert.ok(!/Unexpected token/.test(last),
+    `the whole V8 message must be kept out, not just the part that happens to be secret: ${last}`);
+  assert.ok(last.includes('SyntaxError'), 'the reason is still reported, minus the content');
+});
+
+test('a state.json symlink is never written through', { skip: !posix }, () => {
+    // Deliberately narrow, because the broader claim is false: readState uses
+    // readFileSync, which FOLLOWS the link — the target below holds valid
+    // JSON and its contents ARE read as state. That is not a privilege
+    // boundary: planting the symlink needs write access to a 0700 directory,
+    // and anyone with that owns the account already. What IS guaranteed is
+    // the write side: updateState's tmp+rename replaces the link with a real
+    // file rather than writing through it, so the target is never truncated
+    // or overwritten.
+    // The target holds VALID JSON deliberately. With a non-JSON target the
+    // quarantine renames the link away before any write happens, so the write
+    // path never sees a symlink and the assertion below proves nothing.
+    const d = mkdtempSync(join(tmpdir(), 'unsnooze-symlink-'));
+    const secret = join(d, 'secret.txt');
+    writeFileSync(secret, '{"version":1,"secret":"KEY MATERIAL","sessions":{}}');
+    symlinkSync(secret, join(d, 'state.json'));
+
+    const script = `
+      process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
+      const { readState, updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+      console.log(JSON.stringify(readState().sessions));
+      updateState(s => { s.sessions.probe = { key: 'probe' }; return s; });
+    `;
+    const out = execFileSync(process.execPath, ['--input-type=module', '-e', script], { encoding: 'utf8' });
+    assert.equal(out.trim(), '{}', 'the target is read, but carries no sessions of its own');
+    assert.equal(readFileSync(secret, 'utf-8'), '{"version":1,"secret":"KEY MATERIAL","sessions":{}}',
+      'the pointed-at file is never truncated or written through');
+    assert.ok(!lstatSync(join(d, 'state.json')).isSymbolicLink(),
+      'the write replaced the link with a real file rather than following it');
+    rmSync(d, { recursive: true, force: true });
+  });
+
+test('releaseLock leaves behind a lock that was stolen from us mid-write', () => {
+  // updateState calls acquireLock() OUTSIDE its try/finally, so a writer that
+  // never gets the lock never reaches releaseLock — the only way to exercise
+  // it is from inside the critical section. Here the mutator plays the thief
+  // exactly as acquireLock's steal does (remove the dir, recreate it, stamp a
+  // foreign pid); the finally must then leave that new lock alone.
+  const lock = join(DIR, 'state.lock');
+  rmSync(lock, { recursive: true, force: true });
+  const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
+    process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(DIR)};
+    const { rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    const lock = join(${JSON.stringify(DIR)}, 'state.lock');
+    updateState(s => {
+      // a concurrent stale-lock steal robs us while we are inside
+      rmSync(lock, { recursive: true, force: true });
+      mkdirSync(lock);
+      writeFileSync(join(lock, 'pid'), '999999');
+      return s;
+    });
+    console.log(JSON.stringify({
+      survived: existsSync(join(lock, 'pid')),
+      owner: existsSync(join(lock, 'pid')) ? readFileSync(join(lock, 'pid'), 'utf-8') : null,
+    }));
+  `], { encoding: 'utf8' });
+  const r = JSON.parse(out.trim());
+  assert.equal(r.survived, true, "releaseLock must not delete a lock it no longer owns");
+  assert.equal(r.owner, '999999', "and must leave the thief's stamp intact");
+  rmSync(lock, { recursive: true, force: true });
+});
+
+test('releaseLock still drops a lock that is ours', () => {
+  // A guard on the new pid check, not a regression test — it passes against
+  // the old code too. It exists so a releaseLock that over-refuses (and so
+  // leaks the lock) cannot pass while the test above still does.
+  const lock = join(DIR, 'state.lock');
+  rmSync(lock, { recursive: true, force: true });
+  updateState(s => s);
+  assert.ok(!existsSync(lock), 'the normal path must not leak the lock');
+});
+
+test('an unwritable-but-owned state dir is repaired instead of spinning forever',
+  { skip: !posix || process.getuid?.() === 0 }, () => {
+    // The 1.16.3 bug: mkdir(LOCK_DIR) returns EACCES, which is not EEXIST, and
+    // that branch retried with neither a sleep nor a deadline check — so this
+    // spun at ~70% CPU forever, ignoring LOCK_TIMEOUT_MS, in every writer.
+    const d = mkdtempSync(join(tmpdir(), 'unsnooze-nolock-'));
+    writeFileSync(join(d, 'state.json'), '{"version":1,"sessions":{}}');
+    chmodSync(d, 0o500);   // readable + traversable, NOT writable
+    const started = Date.now();
+    try {
+      execFileSync(process.execPath, ['--input-type=module', '-e', `
+        process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
+        process.env.UNSNOOZE_LOCK_TIMEOUT_MS = '500';
+        const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+        updateState(s => { s.sessions.ok = { key: 'ok' }; return s; });
+      `], { stdio: 'pipe', timeout: 20_000 });
+      assert.ok(Date.now() - started < 15_000, 'must not hot-loop');
+      assert.equal(mode(d), 0o700, 'ensureStateDir repaired the mode it owns');
+    } finally {
+      chmodSync(d, 0o700);
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+test('a lock path that can never be created fails by deadline, not by spinning',
+  { skip: !posix }, () => {
+    // The same branch, where the repair cannot help. STATE_DIR is grown to sit
+    // exactly at the OS path limit, so it is creatable but STATE_DIR/state.lock
+    // overflows — mkdir returns ENAMETOOLONG no matter how often it is retried.
+    // Verified against the pre-fix code: it spun until killed at 6s.
+    const d0 = mkdtempSync(join(tmpdir(), 'unsnooze-nolock2-'));
+    let d = d0;
+    for (;;) {
+      const n = join(d, 'x'.repeat(200));
+      try { mkdirSync(n); d = n; } catch { break; }
+    }
+    for (let pad = 199; pad > 0; pad--) {
+      const n = join(d, 'y'.repeat(pad));
+      try { mkdirSync(n); d = n; break; } catch { /* still too long */ }
+    }
+    // Guard a filesystem whose NAME_MAX is below 200 (eCryptfs is 143): the
+    // probe would make no progress and the lock path would be creatable, so
+    // there would be nothing to assert. Check the real condition, not a
+    // length arithmetic stand-in for it.
+    let overflows = false;
+    try {
+      mkdirSync(join(d, 'state.lock'));
+      rmSync(join(d, 'state.lock'), { recursive: true, force: true });
+    } catch (e) {
+      overflows = e.code === 'ENAMETOOLONG';
+    }
+    if (!overflows) {
+      rmSync(d0, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+      return;
+    }
+    const started = Date.now();
+    try {
+      assert.throws(
+        () => execFileSync(process.execPath, ['--input-type=module', '-e', `
+          process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
+          process.env.UNSNOOZE_LOCK_TIMEOUT_MS = '500';
+          const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+          updateState(s => s);
+        `], { stdio: 'pipe', timeout: 20_000 }),
+        /cannot create state lock/,
+        'an unfixable errno must surface as an error, not a hot loop',
+      );
+      const elapsed = Date.now() - started;
+      assert.ok(elapsed < 15_000, `must give up on the deadline, not spin (took ${elapsed}ms)`);
+    } finally {
+      rmSync(d0, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    }
+  });
+
+// --- the rest of ~/.unsnooze -------------------------------------------------
+
+test('config.json is written owner-only — it carries the ntfy bearer token',
+  { skip: !posix }, async () => {
+    const { setConfigValue } = await import('../src/settings.js');
+    setConfigValue('ntfyToken', 'tk_TEST_BEARER');
+    const f = join(DIR, 'config.json');
+    assert.match(readFileSync(f, 'utf-8'), /tk_TEST_BEARER/);
+    assert.equal(mode(f), 0o600);
+  });
+
+test('hosts.json is written owner-only — it carries credential-source commands',
+  { skip: !posix }, async () => {
+    const { writeHosts } = await import('../src/fleet.js');
+    writeHosts({ box: { dest: 'box', auth: 'password', source: 'command', cmd: 'pass show box' } });
+    assert.equal(mode(join(DIR, 'hosts.json')), 0o600);
+  });
+
+test('the fleet cache is written owner-only — it mirrors remote cwds and prompts',
+  { skip: !posix }, async () => {
+    const { writeFleetCache } = await import('../src/fleet.js');
+    writeFleetCache([{ host: 'box', state: 'ok', sessions: [] }]);
+    assert.equal(mode(join(DIR, 'fleet-cache.json')), 0o600);
+  });
+
+test('a leftover same-pid tmp file cannot carry its mode onto the target',
+  { skip: !posix }, () => {
+    // writeFileSync's `mode` lands only when it CREATES the file. A tmp left
+    // by a crashed predecessor that shared this pid is reused, so without the
+    // chmod after the rename its 0644 rode straight onto state.json.
+    updateState(s => s);
+    const tmp = join(DIR, `.state.tmp.${process.pid}`);
+    writeFileSync(tmp, 'leftover');
+    chmodSync(tmp, 0o644);
+    updateState(s => { s.sessions.reuse = { key: 'reuse' }; return s; });
+    assert.equal(mode(join(DIR, 'state.json')), 0o600);
+  });
+
+test('an existing 0644 config.json is repaired without waiting to be rewritten',
+  { skip: !posix }, async () => {
+    // config.json is only written by `config set`, so an upgraded install
+    // would otherwise keep its 0644 (and its ntfy token) indefinitely.
+    const d = mkdtempSync(join(tmpdir(), 'unsnooze-repair-'));
+    writeFileSync(join(d, 'config.json'), '{"ntfyToken":"tk_legacy"}');
+    chmodSync(join(d, 'config.json'), 0o644);
+    chmodSync(d, 0o755);
+    const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
+      process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
+      const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+      updateState(s => s);   // any state write repairs the dir's known files
+      const { statSync } = await import('node:fs');
+      const m = p => (statSync(p).mode & 0o777).toString(8);
+      console.log(JSON.stringify({ dir: m(${JSON.stringify(d)}), cfg: m(${JSON.stringify(join(d, 'config.json'))}) }));
+    `], { encoding: 'utf8' });
+    const r = JSON.parse(out.trim());
+    assert.equal(r.cfg, '600', 'the token file is narrowed on the next state write');
+    assert.equal(r.dir, '700');
+    rmSync(d, { recursive: true, force: true });
+  });
+
+test('a lock stamped with a live but unrelated pid is stolen past the hard ceiling', () => {
+  // lockHolderAlive() can only ask "is this pid alive". A leaked lock whose
+  // pid is recycled onto some unrelated long-lived process used to wedge
+  // every writer forever; past the ceiling, age alone wins.
+  const lock = join(DIR, 'state.lock');
+  rmSync(lock, { recursive: true, force: true });
+  mkdirSync(lock);
+  writeFileSync(join(lock, 'pid'), String(process.pid));   // very much alive
+  const old = new Date(Date.now() - 30 * 24 * 3_600_000);  // 30 days
+  utimesSync(lock, old, old);
+
+  const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
+    process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(DIR)};
+    process.env.UNSNOOZE_LOCK_TIMEOUT_MS = '2000';
+    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    updateState(s => { s.sessions.unwedged = { key: 'unwedged' }; return s; });
+    console.log('acquired');
+  `], { encoding: 'utf8' });
+  assert.equal(out.trim(), 'acquired');
+  assert.ok(readState().sessions.unwedged, 'the write actually landed');
+});
+
+test('a stale-but-live lock inside the ceiling is still respected', () => {
+  // The ceiling must not become a licence to steal live locks. This has to be
+  // aged PAST the ordinary staleness gate (10s) but inside the ceiling
+  // (300s) — a fresh lock short-circuits on `age > STALE_LOCK_MS` and never
+  // consults HARD_STALE_LOCK_MS at all, so it proves nothing about it.
+  const lock = join(DIR, 'state.lock');
+  rmSync(lock, { recursive: true, force: true });
+  mkdirSync(lock);
+  writeFileSync(join(lock, 'pid'), String(process.pid));   // very much alive
+  const aged = new Date(Date.now() - 15_000);              // > 10s, << 300s
+  utimesSync(lock, aged, aged);
+  assert.throws(
+    () => execFileSync(process.execPath, ['--input-type=module', '-e', `
+      process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(DIR)};
+      process.env.UNSNOOZE_LOCK_TIMEOUT_MS = '300';
+      const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+      updateState(s => s);
+    `], { stdio: 'pipe' }),
+    /lock timeout/,
+    'a live holder inside the ceiling must never be robbed',
+  );
+  assert.equal(readFileSync(join(lock, 'pid'), 'utf-8'), String(process.pid),
+    'and its stamp is untouched');
+  rmSync(lock, { recursive: true, force: true });
+});
+
+test('every writer creates its state-dir entry owner-only', { skip: !posix }, async () => {
+  // The changelog claims "everything under ~/.unsnooze". This is that claim,
+  // and the writer list is derived from the code (every mkdir/write under
+  // STATE_DIR), not from what happened to be convenient to call.
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-allmodes-'));
+  const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
+    process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
+    const { join } = await import('node:path');
+    const R = (m) => import(${JSON.stringify(join(ROOT, 'src'))} + '/' + m);
+    const { updateState } = await R('state.js');
+    const { writeHosts, writeFleetCache } = await R('fleet.js');
+    const { setConfigValue } = await R('settings.js');
+    const { writeUsageStore } = await R('usage.js');
+    const { writeLease } = await R('lease.js');
+    const { recordOwnedSession } = await R('mux-sessions.js');
+    const { writeCache } = await R('update-check.js');
+    const { acquireSingleton } = await R('resumer.js');
+    const { makeLogger } = await R('logger.js');
+    const { ensureAskpassHelper } = await R('askpass.js');
+    updateState(s => s);                                    // state.json
+    writeHosts({ box: 'box' });                             // hosts.json
+    writeFleetCache([]);                                    // fleet-cache.json
+    setConfigValue('ntfyTopic', 'unsnooze-x');              // config.json
+    writeUsageStore({ v: 1 });                              // usage.json
+    writeLease({ leaseId: 'L1', mux: 'tmux', pane: '%1', paneOwner: null, pid: 1 });
+    recordOwnedSession({ mux: 'tmux', name: 'unsnooze' });  // mux-sessions/
+    writeCache({ checkedAt: Date.now() });                  // update-check.json
+    acquireSingleton({ isResumer: () => false });           // resumer.lock
+    makeLogger('test')('hello');                            // unsnooze.log
+    ensureAskpassHelper({ stateDir: ${JSON.stringify(d)}, scriptPath: '/x' });
+    console.log('done');
+  `], { encoding: 'utf8' });
+  assert.equal(out.trim(), 'done');
+  assert.deepEqual(tooOpenUnder(d), [], 'nothing the state dir holds may be group- or world-readable');
+  rmSync(d, { recursive: true, force: true });
+});
+
+test('an upgraded 1.16.3 state dir is repaired, subdirectories included',
+  { skip: !posix }, () => {
+    // The writers alone cannot do this: mkdir's mode is ignored for a
+    // directory that already exists, and an append reuses the file's inode.
+    // 25 lease files and a headless log full of agent output are the real
+    // shape of this on an upgraded machine.
+    const d = mkdtempSync(join(tmpdir(), 'unsnooze-upgrade-'));
+    for (const sub of ['events', 'leases', 'mux-sessions', 'headless']) {
+      mkdirSync(join(d, sub));
+      writeFileSync(join(d, sub, 'old.json'), '{}');
+      chmodSync(join(d, sub, 'old.json'), 0o644);
+      chmodSync(join(d, sub), 0o755);
+    }
+    for (const f of ['config.json', 'update-check.json', 'daemon.log']) {
+      writeFileSync(join(d, f), '{}');
+      chmodSync(join(d, f), 0o644);
+    }
+    chmodSync(d, 0o755);
+    const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
+      process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
+      const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+      updateState(s => s);   // any single state write repairs the whole dir
+      console.log('done');
+    `], { encoding: 'utf8' });
+    assert.equal(out.trim(), 'done');
+    assert.deepEqual(tooOpenUnder(d), [], 'the repair must reach subdirectories and their contents');
+    rmSync(d, { recursive: true, force: true });
+  });
+
+test('the mode repair never chmods through a symlink', { skip: !posix }, () => {
+  // Guard on new behaviour: the old code had no repair to misbehave, so this
+  // passes pre-fix. Mutation-checked instead — dropping the symlink skip
+  // fails it.
+  // chmod follows links, so a state file symlinked elsewhere would otherwise
+  // have its TARGET's mode changed — a write reaching outside the state dir.
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-symrepair-'));
+  const outside = join(d, 'outside.json');
+  writeFileSync(outside, '{"not":"ours"}');
+  chmodSync(outside, 0o644);
+  const state = join(d, 'state');
+  mkdirSync(state);
+  symlinkSync(outside, join(state, 'config.json'));
+  execFileSync(process.execPath, ['--input-type=module', '-e', `
+    process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(state)};
+    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    updateState(s => s);
+  `], { stdio: 'pipe' });
+  assert.equal(mode(outside), 0o644, "the symlink's target must be left alone");
+  rmSync(d, { recursive: true, force: true });
+});
+
+test('ensureStateDir does not narrow a directory that is not the state dir',
+  { skip: !posix }, async () => {
+    // Guard on new behaviour, vacuous against pre-fix code (no narrowing
+    // existed). Mutation-checked: forcing isStateDir true fails it.
+    // writeUsageStore is exported and takes any path; it must not chmod a
+    // caller's project directory or the unrelated files inside it.
+    const d = mkdtempSync(join(tmpdir(), 'unsnooze-foreign-'));
+    writeFileSync(join(d, 'config.json'), '{"someone":"else"}');
+    chmodSync(join(d, 'config.json'), 0o644);
+    chmodSync(d, 0o755);
+    const { writeUsageStore } = await import('../src/usage.js');
+    writeUsageStore({ v: 1 }, join(d, 'usage.json'));
+    assert.equal(mode(join(d, 'config.json')), 0o644, "an unrelated file must not be touched");
+    assert.equal(mode(d), 0o755, "a caller's own directory must not be narrowed");
+    rmSync(d, { recursive: true, force: true });
+  });
+
+test('transcriptPath refuses a session id that is not a safe filename', async () => {
+  // Same class as the statusline shim, on the always-on hook channel:
+  // sessionId arrives in a hook payload and is used as a path component.
+  const { transcriptPath } = await import('../src/sessions.js');
+  const claudeDir = '/claude';
+  assert.equal(transcriptPath('/tmp/proj', '../../../../tmp/pwned', { claudeDir }), null);
+  assert.equal(transcriptPath('/tmp/proj', '/etc/hosts', { claudeDir }), null);
+  assert.equal(transcriptPath('/tmp/proj', 'a/b', { claudeDir }), null);
+  assert.equal(transcriptPath('/tmp/proj', null, { claudeDir }), null);
+  // ...while every id shape a real session actually uses still resolves.
+  for (const id of ['abc-123', 'ab12cd34-5678-90ef-ab12-cd3456789012']) {
+    assert.equal(transcriptPath('/tmp/proj', id, { claudeDir }),
+      join(claudeDir, 'projects', '-tmp-proj', `${id}.jsonl`));
+  }
+});
+
+test('doctor reports and repairs a state dir other users can read', { skip: !posix }, async () => {
+  // ensureStateDir swallows a failed chmod (crashing every state write on a
+  // filesystem without one would be worse), so something has to be able to
+  // say it did not take. doctor is that something.
+  const { findExposedStateFiles, narrowStateModes } = await import('../src/doctor.js');
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-doctor-'));
+  mkdirSync(join(d, 'leases'));
+  writeFileSync(join(d, 'leases', 'a.json'), '{}');
+  writeFileSync(join(d, 'state.json'), '{}');
+  chmodSync(join(d, 'leases', 'a.json'), 0o644);
+  chmodSync(join(d, 'state.json'), 0o644);
+  chmodSync(join(d, 'leases'), 0o755);
+  chmodSync(d, 0o755);
+
+  const found = findExposedStateFiles(d);
+  assert.deepEqual(found.map(f => f.rel).sort(), ['.', 'leases', 'leases/a.json', 'state.json']);
+  assert.deepEqual(narrowStateModes(found), { fixed: 4, refused: 0, ineffective: 0 });
+  assert.deepEqual(findExposedStateFiles(d), [], '--fix leaves nothing exposed');
+  rmSync(d, { recursive: true, force: true });
+});
+
+test('doctor never chmods through a symlink either', { skip: !posix }, async () => {
+  // Guard on new behaviour; doctor's check did not exist pre-fix.
+  const { findExposedStateFiles, narrowStateModes } = await import('../src/doctor.js');
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-doctorsym-'));
+  const outside = join(d, 'outside.json');
+  writeFileSync(outside, '{}');
+  chmodSync(outside, 0o644);
+  const state = join(d, 'state');
+  mkdirSync(state, { mode: 0o700 });
+  symlinkSync(outside, join(state, 'state.json'));
+  narrowStateModes(findExposedStateFiles(state));
+  assert.equal(mode(outside), 0o644, 'the link target keeps its own mode');
+  rmSync(d, { recursive: true, force: true });
+});
+
+test('the workspace fingerprint is computed outside the state lock', { skip: !posix }, () => {
+  // workspaceFingerprint shells out to git, and execFileSync's timeout only
+  // signals the child — a git wedged on a hung mount never returns. Holding
+  // the lock across that is what let a critical section outlive
+  // HARD_STALE_LOCK_MS and be stolen from a writer still working.
+  //
+  // Deterministic rather than timing-based: a stub `git` on PATH records
+  // whether the lock directory existed at the moment it ran.
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-hoist-'));
+  const bin = join(d, 'bin');
+  mkdirSync(bin);
+  const marker = join(d, 'saw-lock');
+  writeFileSync(join(bin, 'git'),
+    `#!/bin/sh\n[ -d "${join(d, 'state', 'state.lock')}" ] && echo held >> "${marker}" || echo free >> "${marker}"\nexit 1\n`,
+    { mode: 0o755 });
+  mkdirSync(join(d, 'state'));
+
+  execFileSync(process.execPath, ['--input-type=module', '-e', `
+    process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(join(d, 'state'))};
+    const { upsertSession } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    upsertSession({
+      sessionId: 'hoist-1', cwd: ${JSON.stringify(d)}, pane: '%1', mux: 'tmux',
+      paneOwner: null, status: 'stopped', detectedAt: Date.now(),
+    });
+  `], { stdio: 'pipe', env: { ...process.env, PATH: `${bin}:${process.env.PATH}` } });
+
+  const observations = readFileSync(marker, 'utf-8').trim().split('\n');
+  assert.ok(observations.length > 0, 'the stub git must actually have run');
+  assert.deepEqual([...new Set(observations)], ['free'],
+    `git ran while the state lock was held: ${observations.join(',')}`);
+  rmSync(d, { recursive: true, force: true });
+});
+
+test('a merged duplicate keeps the ORIGINAL workspace baseline', () => {
+  // The hoist must not become the naive version: assigning the fingerprint to
+  // `record` before the branch would let the merge's {...existing, ...record}
+  // spread it over the baseline captured when the session first stopped.
+  const base = { cwd: '/tmp/proj', pane: '%9', mux: 'tmux', paneOwner: null, status: 'stopped' };
+  const detectedAt = Date.now();
+  upsertSession({ ...base, sessionId: 'dup-1', detectedAt, workspace: { head: 'ORIGINAL', dirtyHash: 'a' } });
+  assert.equal(readState().sessions['dup-1'].workspace.head, 'ORIGINAL');
+
+  // a second detection of the same session, carrying no baseline of its own
+  upsertSession({ ...base, sessionId: 'dup-1', detectedAt: detectedAt + 10 });
+  assert.equal(readState().sessions['dup-1'].workspace.head, 'ORIGINAL',
+    'the merge path must not overwrite the baseline captured at stop time');
+});
+
+test('the mode repair fires even when the state dir carries a trailing slash', { skip: !posix }, () => {
+  // ensureStateDir compares the caller's directory against STATE_DIR to decide
+  // whether the directory is ours to repair. Callers reach it through
+  // dirname(join(STATE_DIR, 'config.json')), which normalizes a trailing slash
+  // away — so a raw string comparison answers "not ours" and skips silently.
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-slash-'));
+  mkdirSync(join(d, 'leases'));
+  writeFileSync(join(d, 'leases', 'o.json'), '{}');
+  chmodSync(join(d, 'leases', 'o.json'), 0o644);
+  chmodSync(join(d, 'leases'), 0o755);
+  chmodSync(d, 0o755);
+  execFileSync(process.execPath, ['--input-type=module', '-e', `
+    process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d + '/')};
+    const { setConfigValue } = await import(${JSON.stringify(join(ROOT, 'src/settings.js'))});
+    setConfigValue('ntfyTopic', 'unsnooze-x');   // writeConfig only — no state write
+  `], { stdio: 'pipe' });
+  assert.deepEqual(tooOpenUnder(d), [], 'a config-only run must still repair the directory');
+  rmSync(d, { recursive: true, force: true });
+});
+
+test('a file that appears after the first repair pass is still narrowed', { skip: !posix }, () => {
+  // daemon.log is created by launchd/systemd redirecting the daemon's stdout,
+  // so it can show up at 0644 AFTER a repair has already run — and the daemon
+  // then lives for days. A once-per-process repair would never revisit it.
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-late-'));
+  const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
+    process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
+    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    const { writeFileSync, statSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const daemonLog = join(${JSON.stringify(d)}, 'daemon.log');
+    updateState(s => s);                          // first repair pass
+    writeFileSync(daemonLog, 'as launchd would'); // arrives afterwards, 0644
+    const at = (statSync(daemonLog).mode & 0o777).toString(8);
+    await new Promise(r => setTimeout(r, 20));
+    updateState(s => s);                          // a later write re-checks
+    console.log(JSON.stringify({ at, after: (statSync(daemonLog).mode & 0o777).toString(8) }));
+  `], { encoding: 'utf8', env: { ...process.env, UNSNOOZE_MODE_REPAIR_MS: '1' } });
+  const r = JSON.parse(out.trim());
+  assert.equal(r.at, '644', 'precondition: nothing of ours created it');
+  assert.equal(r.after, '600', 'a later state write must narrow it');
+  rmSync(d, { recursive: true, force: true });
+});
+
+test('the mode repair strips group and other without destroying the execute bit',
+  { skip: !posix }, () => {
+    // The state dir holds executables — askpass.sh, and whatever else lands
+    // beside it. A flat 0600 turns those into EACCES the next time something
+    // spawns them, which is a far louder bug than the one being fixed.
+    const d = mkdtempSync(join(tmpdir(), 'unsnooze-execbit-'));
+    writeFileSync(join(d, 'runnable.sh'), '#!/bin/sh\necho hi\n');
+    chmodSync(join(d, 'runnable.sh'), 0o755);
+    writeFileSync(join(d, 'plain.json'), '{}');
+    chmodSync(join(d, 'plain.json'), 0o644);
+    chmodSync(d, 0o755);
+    execFileSync(process.execPath, ['--input-type=module', '-e', `
+      process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
+      const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+      updateState(s => s);
+    `], { stdio: 'pipe' });
+    assert.equal(mode(join(d, 'runnable.sh')), 0o700, 'owner keeps +x, group/other lose everything');
+    assert.equal(mode(join(d, 'plain.json')), 0o600);
+    assert.deepEqual(tooOpenUnder(d), []);
+    assert.equal(execFileSync(join(d, 'runnable.sh'), { encoding: 'utf8' }).trim(), 'hi',
+      'and it is still executable afterwards');
+    rmSync(d, { recursive: true, force: true });
+  });
+
+test('doctor sees a state dir that is itself a symlink', { skip: !posix }, async () => {
+  // The scan stats the root rather than lstat'ing it: a dotfiles-managed or
+  // other-volume state dir is a real setup, and refusing to look through the
+  // link turned the whole check off — zero findings while the repair, which
+  // does follow it, was busy fixing things.
+  const { findExposedStateFiles } = await import('../src/doctor.js');
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-symroot-'));
+  const real = join(d, 'real-state');
+  mkdirSync(real);
+  writeFileSync(join(real, 'config.json'), '{}');
+  chmodSync(join(real, 'config.json'), 0o644);
+  chmodSync(real, 0o755);
+  const link = join(d, 'linked-state');
+  symlinkSync(real, link);
+  const found = findExposedStateFiles(link);
+  assert.deepEqual(found.map(f => f.rel).sort(), ['.', 'config.json'],
+    'a symlinked state dir must still be inspected, not silently skipped');
+  rmSync(d, { recursive: true, force: true });
+});
+
+test('the repair fixes leftovers the old allowlist never named', { skip: !posix }, () => {
+  // A quarantined state.json and a crashed writer's tmp file hold verbatim
+  // copies of the state. A fixed list of filenames missed both, so they
+  // stayed world-readable AND doctor reported them forever without the
+  // automatic repair ever clearing the finding.
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-leftovers-'));
+  for (const f of ['state.json.corrupt.1750000000000', '.state.tmp.4242', 'hosts.json.tmp.4242']) {
+    writeFileSync(join(d, f), '{"secret":"copy of state"}');
+    chmodSync(join(d, f), 0o644);
+  }
+  chmodSync(d, 0o755);
+  execFileSync(process.execPath, ['--input-type=module', '-e', `
+    process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
+    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    updateState(s => s);
+  `], { stdio: 'pipe' });
+  assert.deepEqual(tooOpenUnder(d), [], 'leftovers are narrowed like anything else');
+});
+
+test('the permission check is inert on Windows, where the mode bits are synthetic',
+  { skip: !posix }, async () => {
+    // libuv mirrors the owner bits into group and other on Windows, so every
+    // entry reads as 0666/0777 and `mode & 0o077` is never zero — while
+    // chmod there only toggles the read-only attribute. Without this gate
+    // doctor could never report healthy, `--fix` would claim repairs it did
+    // not make, and the daemon would re-chmod the whole directory forever.
+    // (Run from POSIX by injecting the platform; there is no Windows host.)
+    const { scanStateDir } = await import('../src/config.js');
+    const d = mkdtempSync(join(tmpdir(), 'unsnooze-win-'));
+    writeFileSync(join(d, 'config.json'), '{}');
+    chmodSync(join(d, 'config.json'), 0o644);
+    chmodSync(d, 0o755);
+
+    assert.ok(scanStateDir(d, { platform: 'linux' }).length > 0,
+      'precondition: on POSIX this directory is genuinely exposed');
+    assert.deepEqual(scanStateDir(d, { platform: 'win32' }), [],
+      'on Windows the same directory must produce no findings at all');
+    rmSync(d, { recursive: true, force: true });
+  });
+
+test('a hardlinked entry is reported but never chmodded through', { skip: !posix }, async () => {
+  // lstat cannot tell a hardlink from an ordinary file, so chmodding one
+  // would change an inode that also lives outside the state dir. Skipping the
+  // REPAIR is right; skipping the REPORT would hide a genuinely exposed file
+  // from the very check whose job is to surface what the repair cannot fix.
+  const { scanStateDir } = await import('../src/config.js');
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-hardlink-'));
+  const outside = join(d, 'outside.txt');
+  writeFileSync(outside, 'not ours');
+  chmodSync(outside, 0o644);
+  const state = join(d, 'state');
+  mkdirSync(state, { mode: 0o700 });
+  linkSync(outside, join(state, 'linked.json'));
+
+  const found = scanStateDir(state);
+  assert.deepEqual(found.map(e => e.rel), ['linked.json'], 'reported…');
+  assert.equal(found[0].skipRepair, true, '…but flagged as not repairable');
+
+  execFileSync(process.execPath, ['--input-type=module', '-e', `
+    process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(state)};
+    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    updateState(s => s);
+  `], { stdio: 'pipe' });
+  assert.equal(mode(outside), 0o644, 'the shared inode keeps its own mode');
+  rmSync(d, { recursive: true, force: true });
+});
+
+test('the repair count separates changed, refused and silently ignored',
+  { skip: !posix }, async () => {
+    // "chmod did not throw" is not "the mode changed", and the difference is
+    // what made --fix claim success on a filesystem with no POSIX modes.
+    // Exercising only the working path does NOT discriminate — both the honest
+    // and the naive implementation agree there. The discriminating case is
+    // chmod succeeding while the bits stay put, which is reachable portably by
+    // handing narrowStateDir an entry whose `want` is its current mode.
+    const { scanStateDir, narrowStateDir } = await import('../src/config.js');
+    const d = mkdtempSync(join(tmpdir(), 'unsnooze-count-'));
+    writeFileSync(join(d, 'a.json'), '{}');
+    chmodSync(join(d, 'a.json'), 0o644);
+    chmodSync(d, 0o755);
+
+    const found = scanStateDir(d);
+    assert.equal(found.length, 2, 'the dir and the file');
+    assert.deepEqual(narrowStateDir(found), { fixed: 2, refused: 0, ineffective: 0 });
+    assert.deepEqual(narrowStateDir(scanStateDir(d)), { fixed: 0, refused: 0, ineffective: 0 },
+      'nothing left to change');
+
+    // chmod succeeds, bits do not move: must count as ignored, never as fixed.
+    const stuck = join(d, 'a.json');
+    chmodSync(stuck, 0o644);
+    assert.deepEqual(
+      narrowStateDir([{ path: stuck, rel: 'a.json', mode: 0o644, want: 0o644 }]),
+      { fixed: 0, refused: 0, ineffective: 1 },
+      'a no-op chmod is reported as ignored by the filesystem, not as a repair',
+    );
+    rmSync(d, { recursive: true, force: true });
+  });
+
+test('a filesystem that ignores chmod is not walked forever', { skip: !posix }, async () => {
+  // The convergence half of the same problem: without this, a state dir on a
+  // CIFS/vfat mount (or WSL drvfs) is re-chmodded in full every interval for
+  // the life of the daemon, never getting anywhere.
+  const { scanStateDir, narrowStateDir } = await import('../src/config.js');
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-noop-'));
+  writeFileSync(join(d, 'a.json'), '{}');
+  chmodSync(join(d, 'a.json'), 0o644);
+  // Simulate the no-op filesystem by asking for a mode that is already set.
+  const entries = scanStateDir(d).map(e => ({ ...e, want: e.mode }));
+  const r = narrowStateDir(entries);
+  assert.equal(r.fixed, 0);
+  assert.equal(r.refused, 0);
+  assert.ok(r.ineffective > 0, 'the ignored case is what repairModes keys its give-up on');
+  rmSync(d, { recursive: true, force: true });
+});
+
+// F5: this test's title and lead comment described the old non-JSON fixture.
+
+test('runDoctor raises no permission finding on Windows', { skip: !posix }, async () => {
+  // The gate has to hold at the doctor level, not just in scanStateDir:
+  // findExposedStateFiles was not threading `platform`, so runDoctor's own
+  // platform argument — honoured by every other check — was ignored here.
+  const { runDoctor } = await import('../src/doctor.js');
+  const d = mkdtempSync(join(tmpdir(), 'unsnooze-windoctor-'));
+  writeFileSync(join(d, 'config.json'), '{}');
+  chmodSync(join(d, 'config.json'), 0o644);
+  chmodSync(d, 0o755);
+
+  const common = {
+    runner: () => ({ status: 1, stdout: '' }),
+    csgBinPath: null,
+    mux: { available: () => true, name: 'headless' },
+    designRegistered: () => false,
+    hookInstalled: () => true,
+    wrappersInstalled: () => true,
+    stateDir: d,
+  };
+  const posixReport = await runDoctor({ ...common, platform: 'linux' });
+  assert.ok(posixReport.findings.some(f => f.id === 'state-permissions'),
+    'precondition: on POSIX this directory is genuinely exposed');
+
+  const winReport = await runDoctor({ ...common, platform: 'win32' });
+  assert.ok(!winReport.findings.some(f => f.id === 'state-permissions'),
+    'on Windows the mode bits are synthetic — reporting them would never clear');
+  rmSync(d, { recursive: true, force: true });
+});

--- a/test/state-hardening.test.js
+++ b/test/state-hardening.test.js
@@ -19,7 +19,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname } from 'node:path';
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -120,7 +120,7 @@ test('a state.json symlink is never written through', { skip: !posix }, () => {
 
     const script = `
       process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
-      const { readState, updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+      const { readState, updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
       console.log(JSON.stringify(readState().sessions));
       updateState(s => { s.sessions.probe = { key: 'probe' }; return s; });
     `;
@@ -141,11 +141,13 @@ test('releaseLock leaves behind a lock that was stolen from us mid-write', () =>
   // foreign pid); the finally must then leave that new lock alone.
   const lock = join(DIR, 'state.lock');
   rmSync(lock, { recursive: true, force: true });
-  const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
+  let out;
+  try {
+    out = execFileSync(process.execPath, ['--input-type=module', '-e', `
     process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(DIR)};
     const { rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } = await import('node:fs');
     const { join } = await import('node:path');
-    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
     const lock = join(${JSON.stringify(DIR)}, 'state.lock');
     updateState(s => {
       // a concurrent stale-lock steal robs us while we are inside
@@ -159,10 +161,15 @@ test('releaseLock leaves behind a lock that was stolen from us mid-write', () =>
       owner: existsSync(join(lock, 'pid')) ? readFileSync(join(lock, 'pid'), 'utf-8') : null,
     }));
   `], { encoding: 'utf8' });
+  } finally {
+    // The child deliberately leaves a foreign lock behind; if it failed for
+    // any other reason the lock is still there, and every later test in this
+    // file would time out waiting for it. Clean up either way.
+    rmSync(lock, { recursive: true, force: true });
+  }
   const r = JSON.parse(out.trim());
   assert.equal(r.survived, true, "releaseLock must not delete a lock it no longer owns");
   assert.equal(r.owner, '999999', "and must leave the thief's stamp intact");
-  rmSync(lock, { recursive: true, force: true });
 });
 
 test('releaseLock still drops a lock that is ours', () => {
@@ -188,7 +195,7 @@ test('an unwritable-but-owned state dir is repaired instead of spinning forever'
       execFileSync(process.execPath, ['--input-type=module', '-e', `
         process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
         process.env.UNSNOOZE_LOCK_TIMEOUT_MS = '500';
-        const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+        const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
         updateState(s => { s.sessions.ok = { key: 'ok' }; return s; });
       `], { stdio: 'pipe', timeout: 20_000 });
       assert.ok(Date.now() - started < 15_000, 'must not hot-loop');
@@ -236,7 +243,7 @@ test('a lock path that can never be created fails by deadline, not by spinning',
         () => execFileSync(process.execPath, ['--input-type=module', '-e', `
           process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
           process.env.UNSNOOZE_LOCK_TIMEOUT_MS = '500';
-          const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+          const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
           updateState(s => s);
         `], { stdio: 'pipe', timeout: 20_000 }),
         /cannot create state lock/,
@@ -297,7 +304,7 @@ test('an existing 0644 config.json is repaired without waiting to be rewritten',
     chmodSync(d, 0o755);
     const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
       process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
-      const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+      const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
       updateState(s => s);   // any state write repairs the dir's known files
       const { statSync } = await import('node:fs');
       const m = p => (statSync(p).mode & 0o777).toString(8);
@@ -314,6 +321,7 @@ test('a lock stamped with a live but unrelated pid is stolen past the hard ceili
   // pid is recycled onto some unrelated long-lived process used to wedge
   // every writer forever; past the ceiling, age alone wins.
   const lock = join(DIR, 'state.lock');
+  try {
   rmSync(lock, { recursive: true, force: true });
   mkdirSync(lock);
   writeFileSync(join(lock, 'pid'), String(process.pid));   // very much alive
@@ -323,12 +331,15 @@ test('a lock stamped with a live but unrelated pid is stolen past the hard ceili
   const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
     process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(DIR)};
     process.env.UNSNOOZE_LOCK_TIMEOUT_MS = '2000';
-    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
     updateState(s => { s.sessions.unwedged = { key: 'unwedged' }; return s; });
     console.log('acquired');
   `], { encoding: 'utf8' });
   assert.equal(out.trim(), 'acquired');
   assert.ok(readState().sessions.unwedged, 'the write actually landed');
+  } finally {
+    rmSync(lock, { recursive: true, force: true });
+  }
 });
 
 test('a stale-but-live lock inside the ceiling is still respected', () => {
@@ -337,6 +348,7 @@ test('a stale-but-live lock inside the ceiling is still respected', () => {
   // (300s) — a fresh lock short-circuits on `age > STALE_LOCK_MS` and never
   // consults HARD_STALE_LOCK_MS at all, so it proves nothing about it.
   const lock = join(DIR, 'state.lock');
+  try {
   rmSync(lock, { recursive: true, force: true });
   mkdirSync(lock);
   writeFileSync(join(lock, 'pid'), String(process.pid));   // very much alive
@@ -346,7 +358,7 @@ test('a stale-but-live lock inside the ceiling is still respected', () => {
     () => execFileSync(process.execPath, ['--input-type=module', '-e', `
       process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(DIR)};
       process.env.UNSNOOZE_LOCK_TIMEOUT_MS = '300';
-      const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+      const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
       updateState(s => s);
     `], { stdio: 'pipe' }),
     /lock timeout/,
@@ -354,7 +366,9 @@ test('a stale-but-live lock inside the ceiling is still respected', () => {
   );
   assert.equal(readFileSync(join(lock, 'pid'), 'utf-8'), String(process.pid),
     'and its stamp is untouched');
-  rmSync(lock, { recursive: true, force: true });
+  } finally {
+    rmSync(lock, { recursive: true, force: true });
+  }
 });
 
 test('every writer creates its state-dir entry owner-only', { skip: !posix }, async () => {
@@ -365,7 +379,7 @@ test('every writer creates its state-dir entry owner-only', { skip: !posix }, as
   const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
     process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
     const { join } = await import('node:path');
-    const R = (m) => import(${JSON.stringify(join(ROOT, 'src'))} + '/' + m);
+    const R = (m) => import(${JSON.stringify(pathToFileURL(join(ROOT, 'src')).href)} + '/' + m);
     const { updateState } = await R('state.js');
     const { writeHosts, writeFleetCache } = await R('fleet.js');
     const { setConfigValue } = await R('settings.js');
@@ -414,7 +428,7 @@ test('an upgraded 1.16.3 state dir is repaired, subdirectories included',
     chmodSync(d, 0o755);
     const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
       process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
-      const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+      const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
       updateState(s => s);   // any single state write repairs the whole dir
       console.log('done');
     `], { encoding: 'utf8' });
@@ -438,7 +452,7 @@ test('the mode repair never chmods through a symlink', { skip: !posix }, () => {
   symlinkSync(outside, join(state, 'config.json'));
   execFileSync(process.execPath, ['--input-type=module', '-e', `
     process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(state)};
-    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
     updateState(s => s);
   `], { stdio: 'pipe' });
   assert.equal(mode(outside), 0o644, "the symlink's target must be left alone");
@@ -533,7 +547,7 @@ test('the workspace fingerprint is computed outside the state lock', { skip: !po
 
   execFileSync(process.execPath, ['--input-type=module', '-e', `
     process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(join(d, 'state'))};
-    const { upsertSession } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    const { upsertSession } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
     upsertSession({
       sessionId: 'hoist-1', cwd: ${JSON.stringify(d)}, pane: '%1', mux: 'tmux',
       paneOwner: null, status: 'stopped', detectedAt: Date.now(),
@@ -575,7 +589,7 @@ test('the mode repair fires even when the state dir carries a trailing slash', {
   chmodSync(d, 0o755);
   execFileSync(process.execPath, ['--input-type=module', '-e', `
     process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d + '/')};
-    const { setConfigValue } = await import(${JSON.stringify(join(ROOT, 'src/settings.js'))});
+    const { setConfigValue } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/settings.js')).href)});
     setConfigValue('ntfyTopic', 'unsnooze-x');   // writeConfig only — no state write
   `], { stdio: 'pipe' });
   assert.deepEqual(tooOpenUnder(d), [], 'a config-only run must still repair the directory');
@@ -589,7 +603,7 @@ test('a file that appears after the first repair pass is still narrowed', { skip
   const d = mkdtempSync(join(tmpdir(), 'unsnooze-late-'));
   const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
     process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
-    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
     const { writeFileSync, statSync } = await import('node:fs');
     const { join } = await import('node:path');
     const daemonLog = join(${JSON.stringify(d)}, 'daemon.log');
@@ -619,7 +633,7 @@ test('the mode repair strips group and other without destroying the execute bit'
     chmodSync(d, 0o755);
     execFileSync(process.execPath, ['--input-type=module', '-e', `
       process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
-      const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+      const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
       updateState(s => s);
     `], { stdio: 'pipe' });
     assert.equal(mode(join(d, 'runnable.sh')), 0o700, 'owner keeps +x, group/other lose everything');
@@ -663,7 +677,7 @@ test('the repair fixes leftovers the old allowlist never named', { skip: !posix 
   chmodSync(d, 0o755);
   execFileSync(process.execPath, ['--input-type=module', '-e', `
     process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
-    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
     updateState(s => s);
   `], { stdio: 'pipe' });
   assert.deepEqual(tooOpenUnder(d), [], 'leftovers are narrowed like anything else');
@@ -710,7 +724,7 @@ test('a hardlinked entry is reported but never chmodded through', { skip: !posix
 
   execFileSync(process.execPath, ['--input-type=module', '-e', `
     process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(state)};
-    const { updateState } = await import(${JSON.stringify(join(ROOT, 'src/state.js'))});
+    const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
     updateState(s => s);
   `], { stdio: 'pipe' });
   assert.equal(mode(outside), 0o644, 'the shared inode keeps its own mode');
@@ -767,31 +781,32 @@ test('a filesystem that ignores chmod is not walked forever', { skip: !posix }, 
 
 // F5: this test's title and lead comment described the old non-JSON fixture.
 
-test('runDoctor raises no permission finding on Windows', { skip: !posix }, async () => {
-  // The gate has to hold at the doctor level, not just in scanStateDir:
-  // findExposedStateFiles was not threading `platform`, so runDoctor's own
-  // platform argument — honoured by every other check — was ignored here.
-  const { runDoctor } = await import('../src/doctor.js');
-  const d = mkdtempSync(join(tmpdir(), 'unsnooze-windoctor-'));
-  writeFileSync(join(d, 'config.json'), '{}');
-  chmodSync(join(d, 'config.json'), 0o644);
-  chmodSync(d, 0o755);
+test('the permission check keys off the real filesystem, not a simulated platform',
+  { skip: !posix }, async () => {
+    // runDoctor's `platform` simulates an install target. Whether chmod means
+    // anything is a property of the host filesystem, so this check must not
+    // read the simulated value — doing so raised the finding on a Windows
+    // runner for a test that had injected 'darwin', where no repair could
+    // ever clear it. scanStateDir's own platform option stays injectable.
+    const { runDoctor } = await import('../src/doctor.js');
+    const d = mkdtempSync(join(tmpdir(), 'unsnooze-windoctor-'));
+    writeFileSync(join(d, 'config.json'), '{}');
+    chmodSync(join(d, 'config.json'), 0o644);
+    chmodSync(d, 0o755);
 
-  const common = {
-    runner: () => ({ status: 1, stdout: '' }),
-    csgBinPath: null,
-    mux: { available: () => true, name: 'headless' },
-    designRegistered: () => false,
-    hookInstalled: () => true,
-    wrappersInstalled: () => true,
-    stateDir: d,
-  };
-  const posixReport = await runDoctor({ ...common, platform: 'linux' });
-  assert.ok(posixReport.findings.some(f => f.id === 'state-permissions'),
-    'precondition: on POSIX this directory is genuinely exposed');
-
-  const winReport = await runDoctor({ ...common, platform: 'win32' });
-  assert.ok(!winReport.findings.some(f => f.id === 'state-permissions'),
-    'on Windows the mode bits are synthetic — reporting them would never clear');
-  rmSync(d, { recursive: true, force: true });
-});
+    const common = {
+      runner: () => ({ status: 1, stdout: '' }),
+      csgBinPath: null,
+      mux: { available: () => true, name: 'headless' },
+      designRegistered: () => false,
+      hookInstalled: () => true,
+      wrappersInstalled: () => true,
+      stateDir: d,
+    };
+    for (const platform of ['linux', 'win32', 'darwin']) {
+      const report = await runDoctor({ ...common, platform });
+      assert.ok(report.findings.some(f => f.id === 'state-permissions'),
+        `simulating ${platform} must not change what this POSIX filesystem reports`);
+    }
+    rmSync(d, { recursive: true, force: true });
+  });

--- a/test/statusline-shim.test.js
+++ b/test/statusline-shim.test.js
@@ -1,0 +1,93 @@
+// The generated statusLine shim turns Claude Code's session_id into a
+// filename. Before 1.17.0 it used the value verbatim, so a session_id
+// containing a '/' walked the drop file out of ~/.claude/unsnooze.
+//
+// The traversal cases fail against the pre-fix shim. The well-formed-id case
+// does NOT — it passed before too — and is kept deliberately: it is the only
+// thing that would catch a gate tightened so far it rejects real session ids.
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync, rmSync, existsSync, readdirSync, readFileSync, mkdirSync,
+  writeFileSync, chmodSync, statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const DIR = mkdtempSync(join(tmpdir(), 'unsnooze-shim-'));
+process.env.UNSNOOZE_STATE_DIR = join(DIR, 'state');
+
+const { writeStatuslineShimScript } = await import('../src/usage.js');
+
+after(() => rmSync(DIR, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }));
+
+// The shim always drops into ~/.claude/unsnooze, so point HOME at a scratch
+// dir and read the result from there.
+function runShim(payload) {
+  const home = mkdtempSync(join(DIR, 'home-'));
+  const shim = writeStatuslineShimScript(join(DIR, 'shimdir'));
+  const out = execFileSync(process.execPath, [shim], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home, USERPROFILE: home, UNSNOOZE_STATUSLINE_ORIG: '' },
+  });
+  return { home, out, dropDir: join(home, '.claude', 'unsnooze') };
+}
+
+test('a well-formed session id still gets its own drop file', () => {
+  const { dropDir } = runShim({
+    session_id: 'ab12cd34-5678-90ef-ab12-cd3456789012',
+    rate_limits: { five_hour: { used_percentage: 42 } },
+  });
+  const files = readdirSync(dropDir);
+  assert.deepEqual(files, ['usage-ab12cd34-5678-90ef-ab12-cd3456789012.json']);
+  const drop = JSON.parse(readFileSync(join(dropDir, files[0]), 'utf-8'));
+  assert.equal(drop.rate_limits.five_hour.used_percentage, 42);
+});
+
+test('a traversing session id cannot escape the drop directory', () => {
+  const { home, dropDir, out } = runShim({
+    session_id: 'x/../../../../PWNED',
+    rate_limits: { five_hour: { used_percentage: 7 } },
+  });
+  assert.ok(!existsSync(join(home, 'PWNED.json')), 'must not write outside ~/.claude/unsnooze');
+  assert.ok(!existsSync(join(home, '..', 'PWNED.json')));
+  assert.deepEqual(readdirSync(dropDir), ['usage-unknown.json'],
+    'an id that is not filename-shaped falls back to "unknown"');
+  assert.equal(out.trim(), 'unsnooze 7%', 'the statusline itself still renders');
+});
+
+test('an absolute session id cannot pick its own path', () => {
+  const { dropDir } = runShim({ session_id: '/etc/unsnooze-pwned', rate_limits: {} });
+  assert.deepEqual(readdirSync(dropDir), ['usage-unknown.json']);
+});
+
+test('a non-string session id does not crash the shim', () => {
+  const { dropDir, out } = runShim({ session_id: { nested: true }, rate_limits: {} });
+  assert.deepEqual(readdirSync(dropDir), ['usage-unknown.json']);
+  assert.equal(out.trim(), 'unsnooze ?', 'no five_hour data renders as "?", not a crash');
+});
+
+test('the shim repairs a drop directory left world-readable by an older install', () => {
+  // mkdir's mode is ignored for a directory that already exists, so every
+  // pre-1.17.0 install kept 0755/0644 forever — the same gap the state dir
+  // got a repair for, one directory over.
+  if (process.platform === 'win32') return;
+  const home = mkdtempSync(join(DIR, 'legacyhome-'));
+  const dropDir = join(home, '.claude', 'unsnooze');
+  mkdirSync(dropDir, { recursive: true });
+  writeFileSync(join(dropDir, 'usage-old.json'), '{}');
+  chmodSync(join(dropDir, 'usage-old.json'), 0o644);
+  chmodSync(dropDir, 0o755);
+
+  const shim = writeStatuslineShimScript(join(DIR, 'shimdir'));
+  execFileSync(process.execPath, [shim], {
+    input: JSON.stringify({ session_id: 'ab12cd34-5678-90ef-ab12-cd3456789012', rate_limits: {} }),
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home, USERPROFILE: home, UNSNOOZE_STATUSLINE_ORIG: '' },
+  });
+  const mode = p => statSync(p).mode & 0o777;
+  assert.equal(mode(dropDir), 0o700, 'the drop directory is narrowed on the next run');
+  assert.equal(mode(join(dropDir, 'usage-ab12cd34-5678-90ef-ab12-cd3456789012.json')), 0o600);
+});

--- a/test/windows-platform.test.js
+++ b/test/windows-platform.test.js
@@ -20,6 +20,14 @@ import { runDoctor } from '../src/doctor.js';
 import { powershellProfilePath } from '../src/powershell.js';
 import {
 } from '../src/install.js';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// runDoctor's state-permissions check defaults to the real ~/.unsnooze. These
+// tests assert on wrapper findings only, but without a pinned directory the
+// report they build would depend on the developer's own machine — and the
+// walk would read whatever that machine happens to have there.
+const NO_STATE_DIR = join(tmpdir(), 'unsnooze-windows-test-nostate');
 
 // --- StopFailure hook command ---------------------------------------------
 
@@ -227,6 +235,7 @@ test('doctor looks for the wrapper where the platform actually puts it', async (
   // an install they already did.
   const withBlock = installPowershellBlock('', ['claude'], 'C:\\u.js');
   const report = await runDoctor({
+    stateDir: NO_STATE_DIR,
     platform: 'win32',
     runner: () => ({ status: 1, stdout: '' }),
     csgBinPath: null,
@@ -242,6 +251,7 @@ test('doctor looks for the wrapper where the platform actually puts it', async (
 
 test('doctor still reports a genuinely missing windows wrapper', async () => {
   const report = await runDoctor({
+    stateDir: NO_STATE_DIR,
     platform: 'win32',
     runner: () => ({ status: 1, stdout: '' }),
     csgBinPath: null,


### PR DESCRIPTION
Raised by #17, though mostly not the findings in it. Five review rounds; the full verdict on each reported item goes in the issue.

## What was actually wrong

**The state lock could spin at ~70% of a core, forever.** `acquireLock` treated every `mkdir` failure as contention. `EEXIST` is contention; `EACCES` on an unwritable `~/.unsnooze`, `EROFS`, and `ENOSPC` are not — and that branch retried with neither a sleep nor a deadline check. Since `mkdir -p` on an existing directory succeeds as a no-op, nothing broke the cycle: `UNSNOOZE_LOCK_TIMEOUT_MS` never applied and the loop never exited, taking every writer with it — the daemon, the CLI, and the StopFailure hook that runs inside the agent. Measured at 70.5% CPU, state `RN`, still going when killed.

**`~/.unsnooze` was world-readable.** 0755 with 0644 files, holding an ntfy bearer token, queued prompt text, the fleet's ssh destinations and credential-source commands, and — for a headless revival — the entire stdout of an unattended agent run. Every writer now creates owner-only, and because `mkdir`'s mode is ignored for an existing directory and `config.json` is only written by `config set`, an upgraded install is repaired on the next state write rather than waiting for someone to touch each file.

**`session_id` was used directly as a filename in three places.** It arrives in a payload from the agent. The statusline shim's *write* escaped `~/.claude/unsnooze` over any `.json` the user can write; `transcriptPath` on the always-on hook path turned a read of your own transcript into a read of any `.jsonl`; the Kimi adapter leaked whether an arbitrary path exists.

**A leaked lock could wedge every writer permanently.** Liveness was decided by signalling the recorded pid, which can't distinguish "unsnooze is working" from "that number now belongs to some unrelated long-lived process".

## Notes for review

Minor, not patch: the first run after upgrading changes file permissions inside the user's home directory.

Permissions are inert where they cannot mean anything — Windows synthesises the POSIX bits, and so do CIFS/vfat/WSL `drvfs` mounts where `process.platform` still reads `linux`. That is detected by attempting the change and looking, not by the platform name.

Three existing test suites reached the developer's real `~/.unsnooze`; `dashboard.test.js` was the sharp one, since `readState` quarantines a file it cannot parse. All pinned, and an fs recorder over the full suite now shows zero mutating operations against it.

41 new tests, 32 of which fail against the pre-fix tree; the rest are guards on new behaviour and say so in place. Three were rewritten after review showed their fixtures never reached the code under test.

## Known limits

The Windows and CIFS behaviour is reasoned from libuv's documented semantics, not observed on a real host — this PR's Windows CI leg is the first real signal. Two transient test failures were seen across the work and never reproduced in ~20 subsequent runs, including under CPU load; neither was captured by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)