### PR TITLE
feat(install): fish shell support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+**fish shell support.** Wrappers now install into `~/.config/fish/config.fish`
+when the file exists or fish is the login shell — `unsnooze setup` covers fish
+users with no extra steps, `unsnooze uninstall` removes the block, and
+`unsnooze doctor` checks the fish config when the POSIX rc files are empty.
+The fish block is the same guarded wrapper as the zsh/bash one (`UNSNOOZE_ACTIVE`
+recursion guard, fallback to the real CLI if the entry point vanishes,
+`_run <id>` routing) written in fish syntax: `name() { … }` is a parse error
+there, so `$?` becomes `$status` and the body uses `test` / `or` / `not`.
+An explicit `--fishrc <path>` override targets a different file (tests, CI).
+
 ## 1.18.0 — 2026-09-02
 
 **Cursor CLI support**, a wrapper change that keeps `cursor .` working, and a

--- a/README.md
+++ b/README.md
@@ -680,7 +680,8 @@ watcher stops (no pane context) always use native.
   [Watching without a multiplexer](#watching-without-a-multiplexer))
 - tmux ≥ 3.2, Zellij, **or** herdr ≥ 0.8.0 for pane-level watching. Optional:
   without one, unsnooze runs `headless` and still catches and resumes stops.
-- zsh or bash (wrappers go into `~/.zshrc` / `~/.bashrc`), or PowerShell
+- zsh or bash (wrappers go into `~/.zshrc` / `~/.bashrc`), fish (wrappers go
+  into `~/.config/fish/config.fish`), or PowerShell
   (wrappers go into `$PROFILE.CurrentUserAllHosts`)
 
 ### Supported terminals

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -16,6 +16,7 @@ import { makeLogger } from './logger.js';
 import { shouldUseTui, formatDoctorTui } from './tui.js';
 import { designRegisteredOffline } from './design.js';
 import { powershellProfilePath } from './powershell.js';
+import { fishConfigPath } from './fish.js';
 
 const log = makeLogger('doctor');
 
@@ -116,13 +117,14 @@ function readOrEmpty(path) {
 // wrappers installed" is a health question — but it has to be asked of the
 // right file. A PowerShell user has no ~/.zshrc, so checking only the POSIX rc
 // files made every native-Windows `unsnooze doctor` report the wrappers
-// missing and point the user at an install they had already run.
+// missing and point the user at an install they had already run. A fish user
+// has no POSIX rc wrapper either — their block lives in the fish config.
 function defaultWrappersInstalled({
   platform = process.platform,
   rcContent = readOrEmpty,
   profileContent = null,
 } = {}) {
-  const rcs = [join(homedir(), '.zshrc'), join(homedir(), '.bashrc')];
+  const rcs = [join(homedir(), '.zshrc'), join(homedir(), '.bashrc'), fishConfigPath()];
   if (rcs.some(rc => rcContent(rc).includes(WRAPPER_MARK))) return true;
   if (platform !== 'win32') return false;
   const readProfile = profileContent

--- a/src/fish.js
+++ b/src/fish.js
@@ -1,0 +1,22 @@
+// Where the fish shell looks for its config.
+//
+// A leaf module (node builtins only) on purpose — the same reason
+// powershell.js exists: install.js already imports doctor.js, and doctor.js
+// needs this to answer "are the wrappers installed?" for fish users.
+// Declaring it in install.js would close that loop (see
+// test/module-graph.test.js for what that breaks).
+//
+// fish reads its config from <config-home>/fish/config.fish, where
+// <config-home> honors XDG_CONFIG_HOME (absolute paths only — the XDG spec
+// says a relative value must be ignored, and fish follows that).
+
+import { homedir } from 'node:os';
+import { join, isAbsolute } from 'node:path';
+
+export function fishConfigPath({ env = process.env, home = homedir() } = {}) {
+  // Test/CI override, matching UNSNOOZE_QWEN_DIR and the autostart dir vars.
+  if (env.UNSNOOZE_FISH_CONFIG) return env.UNSNOOZE_FISH_CONFIG;
+  const xdg = env.XDG_CONFIG_HOME;
+  if (xdg && isAbsolute(xdg)) return join(xdg, 'fish', 'config.fish');
+  return join(home, '.config', 'fish', 'config.fish');
+}

--- a/src/install.js
+++ b/src/install.js
@@ -5,8 +5,11 @@
 //     atomic write)
 //   - ~/.zshrc + ~/.bashrc: one fence-marked block with a wrapper function per
 //     enabled agent (claude/codex/grok), routed through `unsnooze _run`
+//   - ~/.config/fish/config.fish: the same block in fish syntax (fish shares
+//     no syntax with POSIX rc files — a bash function there is a parse error)
 //   - ~/.grok/hooks/unsnooze.json when the grok agent is enabled
-// --settings <path> / --zshrc <path> override targets (used by tests).
+// --settings <path> / --zshrc <path> / --fishrc <path> override targets (used
+// by tests).
 
 import { readFileSync, writeFileSync, renameSync, existsSync, copyFileSync, rmSync, mkdirSync, unlinkSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
@@ -21,6 +24,7 @@ import { findCsgProcesses, findCsgAutostarts } from './doctor.js';
 import { UNSNOOZE_BIN, stopResumer } from './spawn.js';
 import { uninstallStatuslineShim } from './usage.js';
 import { powershellProfilePath } from './powershell.js';
+import { fishConfigPath } from './fish.js';
 
 const FENCE_OPEN = '# >>> unsnooze >>>';
 const FENCE_CLOSE = '# <<< unsnooze <<<';
@@ -33,13 +37,17 @@ const LEGACY_FENCES = [
 const OLD_FENCE_OPEN = LEGACY_FENCES[0].open;
 
 function parseArgs(rest) {
-  const opts = { yes: false, settings: CLAUDE_SETTINGS, zshrc: join(homedir(), '.zshrc'), purge: false, daemon: false };
+  const opts = {
+    yes: false, settings: CLAUDE_SETTINGS, zshrc: join(homedir(), '.zshrc'),
+    fishrc: fishConfigPath(), purge: false, daemon: false,
+  };
   for (let i = 0; i < rest.length; i++) {
     if (rest[i] === '--yes' || rest[i] === '-y') opts.yes = true;
     else if (rest[i] === '--purge') opts.purge = true;
     else if (rest[i] === '--daemon') opts.daemon = true;
     else if (rest[i] === '--settings') opts.settings = rest[++i];
     else if (rest[i] === '--zshrc') opts.zshrc = rest[++i];
+    else if (rest[i] === '--fishrc') opts.fishrc = rest[++i];
   }
   return opts;
 }
@@ -202,6 +210,38 @@ export function installZshrcBlock(content, agents = ['claude']) {
   ({ content: cleaned } = stripFencedBlock(cleaned, FENCE_OPEN, FENCE_CLOSE));
   const result = cleaned.replace(/\n+$/, '\n') + '\n' + wrapperBlock(agents) + '\n';
   return { content: result, oldRemoved };
+}
+
+// The fish twin of wrapperBlock(). Fish shares no syntax with the POSIX block:
+// `name() { … }` is a parse error there, `$?` is `$status`, and `"${X}"` is
+// `"${X}"` verbatim text — so the wrapper gets its own body. Same semantics as
+// the zsh/bash wrapper: a recursion guard (UNSNOOZE_ACTIVE), the load-bearing
+// missing-file fallback to the real CLI, and `_run <id>` routing.
+//
+// Redefining a function replaces any earlier one, which covers fish "aliases"
+// (they are functions too) — no `unalias` analogue is needed. Fish comments
+// are `#`, so the same fence markers work and stripFencedBlock() removes it
+// unchanged.
+export function fishWrapperBlock(agents = ['claude'], bin = UNSNOOZE_BIN) {
+  const fns = agents.flatMap(id => wrapperNamesFor(id).map(name => `function ${name} --description 'unsnooze-wrapped ${name}'
+  if test "$UNSNOOZE_ACTIVE" = "1"; or not test -f '${bin}'
+    command ${name} $argv
+    return $status
+  end
+  node '${bin}' _run ${id} $argv
+end`)).join('\n');
+  return `${FENCE_OPEN}
+# unsnooze wrappers: route every interactive launch of the CLIs below through
+# unsnooze so limit stops are recorded and auto-resumed.
+${fns}
+${FENCE_CLOSE}`;
+}
+
+// installZshrcBlock's fish twin. Same fence, same replace-don't-append
+// behaviour, so re-running setup never stacks a second copy of the wrappers.
+export function installFishBlock(content, agents = ['claude'], bin = UNSNOOZE_BIN) {
+  const { content: cleaned } = stripFencedBlock(content, FENCE_OPEN, FENCE_CLOSE);
+  return cleaned.replace(/\n+$/, '\n') + '\n' + fishWrapperBlock(agents, bin) + '\n';
 }
 
 // --- daemon autostart ---
@@ -555,6 +595,22 @@ function rcTargets(opts, explicit) {
   return existing.length > 0 ? existing : [opts.zshrc];
 }
 
+// The fish config is a separate target from the POSIX rc loop: fish syntax
+// shares nothing with bash, so it gets its own block, and fish reads only
+// <config-home>/fish/config.fish. Touch it when the file already exists (the
+// same any-rc rule as zsh/bash), or when fish is the login shell — a fish
+// user may not have created config.fish yet, and a wrapper that would never
+// load is the same silent-miss as a profile written to a guessed path. Empty
+// list = no evidence of fish on this machine; leave it alone.
+function fishTargets(opts, explicit) {
+  if (explicit) return [opts.fishrc];
+  const cfg = fishConfigPath();
+  if (existsSync(cfg)) return [cfg];
+  const loginShell = process.env.SHELL || userInfo().shell;
+  if (typeof loginShell === 'string' && /(^|\/|\\)fish$/.test(loginShell)) return [cfg];
+  return [];
+}
+
 export function cmdInstall(rest, { agents = enabledAgents() } = {}) {
   const opts = parseArgs(rest);
   const explicitRc = rest.includes('--zshrc');
@@ -620,6 +676,21 @@ export function cmdInstall(rest, { agents = enabledAgents() } = {}) {
       console.log(`unsnooze: PowerShell wrappers (${agents.join(', ')}) installed in ${psProfile}`);
     } catch (err) {
       console.log(`unsnooze: could not write the PowerShell profile (${err.message})`);
+    }
+  }
+
+  // 3c. Fish config. The POSIX loop above is a parse error in fish, and the
+  //     PowerShell profile never loads there — fish needs its own block or a
+  //     fish user's `claude` never routes through unsnooze at all.
+  for (const cfg of fishTargets(opts, rest.includes('--fishrc'))) {
+    try {
+      mkdirSync(dirname(cfg), { recursive: true });
+      const before = existsSync(cfg) ? readFileSync(cfg, 'utf-8') : '';
+      if (existsSync(cfg)) backupOnce(cfg);
+      atomicWrite(cfg, installFishBlock(before, agents, UNSNOOZE_BIN));
+      console.log(`unsnooze: fish wrappers (${agents.join(', ')}) installed in ${cfg}`);
+    } catch (err) {
+      console.log(`unsnooze: could not write the fish config (${err.message})`);
     }
   }
 
@@ -696,6 +767,17 @@ export function cmdUninstall(rest) {
     }
   } catch (err) {
     console.log(`unsnooze: could not clean the PowerShell profile (${err.message})`);
+  }
+
+  // The fish config is a wrapper site too, same reason as the PowerShell
+  // profile above: a stale block would keep shadowing the real CLI.
+  for (const cfg of fishTargets(opts, rest.includes('--fishrc'))) {
+    if (!existsSync(cfg)) continue;
+    const { content, found } = stripFencedBlock(readFileSync(cfg, 'utf-8'), FENCE_OPEN, FENCE_CLOSE);
+    if (found) {
+      atomicWrite(cfg, content);
+      console.log(`unsnooze: fish wrappers removed from ${cfg}`);
+    }
   }
 
   const autostart = uninstallDaemonAutostart();

--- a/test/fish-install.test.js
+++ b/test/fish-install.test.js
@@ -1,0 +1,226 @@
+// fish shell support: wrappers into ~/.config/fish/config.fish.
+// Fish shares no syntax with the POSIX rc block (`name() { … }` is a parse
+// error there, `$?` is `$status`), so install.js carries a separate fish
+// block, its own target selection, and uninstall coverage — everything
+// asserted here mirrors the zsh/bash cases in install.test.js.
+
+const AUTOSTART_ISOLATION = mkdtempSync(join(tmpdir(), 'unsnooze-fish-autostart-'));
+process.env.UNSNOOZE_LAUNCH_AGENTS_DIR = join(AUTOSTART_ISOLATION, 'LaunchAgents');
+process.env.UNSNOOZE_SYSTEMD_USER_DIR = join(AUTOSTART_ISOLATION, 'systemd');
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+import {
+  cmdInstall, cmdUninstall, installFishBlock, fishWrapperBlock, stripFencedBlock,
+} from '../src/install.js';
+import { fishConfigPath } from '../src/fish.js';
+
+test('fishConfigPath honors XDG_CONFIG_HOME (absolute only) and UNSNOOZE_FISH_CONFIG', () => {
+  assert.equal(
+    fishConfigPath({ env: { XDG_CONFIG_HOME: '/x/cfg' }, home: '/home/me' }),
+    join('/x/cfg', 'fish', 'config.fish'));
+  // A relative XDG value must be ignored per the XDG spec.
+  assert.equal(
+    fishConfigPath({ env: { XDG_CONFIG_HOME: 'rel/path' }, home: '/home/me' }),
+    join('/home/me', '.config', 'fish', 'config.fish'));
+  assert.equal(
+    fishConfigPath({ env: { UNSNOOZE_FISH_CONFIG: '/override/cfg.fish' }, home: '/home/me' }),
+    '/override/cfg.fish');
+  assert.equal(
+    fishConfigPath({ env: {}, home: '/home/me' }),
+    join('/home/me', '.config', 'fish', 'config.fish'));
+});
+
+test('fish wrapper block contains one function per enabled agent, routed via _run', () => {
+  const content = installFishBlock('', ['claude', 'codex']);
+  assert.match(content, /function claude /);
+  assert.match(content, /function codex /);
+  assert.ok(!content.includes('function grok '), 'disabled agents get no wrapper');
+  assert.match(content, /_run claude \$argv/);
+  assert.match(content, /_run codex \$argv/);
+  assert.match(content, /UNSNOOZE_ACTIVE/);
+  // fish exit-status plumbing, not POSIX `$?`.
+  assert.match(content, /return \$status/);
+  assert.ok(!content.includes('$?'), 'POSIX $? has no meaning in fish');
+  assert.equal(content.split('# >>> unsnooze >>>').length, 2);
+});
+
+test('cursor wraps cursor-agent, never the bare cursor command', () => {
+  const content = installFishBlock('', ['cursor']);
+  assert.match(content, /function cursor-agent /);
+  assert.ok(!content.includes('function cursor '), 'the IDE launcher must never be shadowed');
+  assert.match(content, /_run cursor \$argv/, 'the _run argument stays the agent id');
+});
+
+test('fish wrapper falls back to the real CLI when the unsnooze entry point is gone', () => {
+  // Same load-bearing guard as the POSIX wrapper: a vanished bin must degrade
+  // to the plain CLI, never brick the command.
+  const content = installFishBlock('', ['claude']);
+  const guard = content.match(/not test -f '([^']+)'/);
+  assert.ok(guard, 'wrapper must check the entry point exists before exec-ing it');
+  assert.match(guard[1], /unsnooze\.js$/);
+});
+
+test('installFishBlock is replace-don-append, like the POSIX twin', () => {
+  const first = { content: installFishBlock('# my fish config\n', ['claude', 'grok']) };
+  assert.equal(first.content.split('# >>> unsnooze >>>').length, 2);
+  assert.ok(first.content.startsWith('# my fish config'));
+  const second = { content: installFishBlock(first.content, ['claude']) };
+  assert.equal(second.content.split('# >>> unsnooze >>>').length, 2, 're-run must never stack a second block');
+  assert.ok(!second.content.includes('function grok '), 'replaced block reflects the new agent set');
+  assert.ok(second.content.includes('# my fish config'));
+});
+
+test('generated block parses as real fish (skipped when fish is not installed)', () => {
+  let fish = null;
+  try { fish = execFileSync('which', ['fish'], { encoding: 'utf-8' }).trim(); } catch { /* absent */ }
+  if (!fish) return;
+  const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-parse-'));
+  try {
+    const content = installFishBlock('', ['claude', 'codex', 'grok', 'qwen', 'kimi', 'opencode', 'agy', 'cursor']);
+    const f = join(dir, 'config.fish');
+    writeFileSync(f, content);
+    execFileSync(fish, ['-n', f], { stdio: ['ignore', 'ignore', 'pipe'] });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the fish block round-trips through stripFencedBlock for uninstall', () => {
+  const installed = installFishBlock('set -x EDITOR nvim\n', ['claude']);
+  const { content, found } = stripFencedBlock(installed, '# >>> unsnooze >>>', '# <<< unsnooze <<<');
+  assert.equal(found, true);
+  assert.ok(!content.includes('_run'));
+  assert.match(content, /set -x EDITOR nvim/);
+});
+
+test('cmdInstall writes the fish config at --fishrc, backing up first', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-install-'));
+  try {
+    const settings = join(dir, 'settings.json');
+    const rc = join(dir, 'zshrc');
+    const fishrc = join(dir, 'config.fish');
+    writeFileSync(fishrc, '# my fish config\n');
+    const code = cmdInstall(['--yes', '--settings', settings, '--zshrc', rc, '--fishrc', fishrc], { agents: ['claude'] });
+    assert.equal(code, 0);
+    const out = readFileSync(fishrc, 'utf-8');
+    assert.match(out, /# >>> unsnooze >>>/);
+    assert.match(out, /function claude /);
+    assert.match(readFileSync(`${fishrc}.unsnooze-orig`, 'utf-8'), /my fish config/,
+      'first run snapshots the pre-unsnooze fish config');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('cmdInstall creates config.fish when fish is the login shell', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-login-'));
+  const prevFish = process.env.UNSNOOZE_FISH_CONFIG;
+  const prevShell = process.env.SHELL;
+  try {
+    // Point the fish target into the tmp dir, then pretend fish is the login
+    // shell with no config.fish yet — a fish user's first-run case.
+    process.env.UNSNOOZE_FISH_CONFIG = join(dir, 'config.fish');
+    process.env.SHELL = '/usr/bin/fish';
+    const settings = join(dir, 'settings.json');
+    const rc = join(dir, 'zshrc');
+    assert.ok(!existsSync(join(dir, 'config.fish')));
+    const code = cmdInstall(['--yes', '--settings', settings, '--zshrc', rc], { agents: ['claude'] });
+    assert.equal(code, 0);
+    assert.match(readFileSync(join(dir, 'config.fish'), 'utf-8'), /function claude /);
+  } finally {
+    if (prevFish === undefined) delete process.env.UNSNOOZE_FISH_CONFIG; else process.env.UNSNOOZE_FISH_CONFIG = prevFish;
+    if (prevShell === undefined) delete process.env.SHELL; else process.env.SHELL = prevShell;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('cmdInstall leaves fish alone when there is no fish on the machine', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-absent-'));
+  const prevFish = process.env.UNSNOOZE_FISH_CONFIG;
+  const prevShell = process.env.SHELL;
+  try {
+    process.env.UNSNOOZE_FISH_CONFIG = join(dir, 'config.fish');
+    process.env.SHELL = '/bin/bash';
+    const settings = join(dir, 'settings.json');
+    const rc = join(dir, 'zshrc');
+    const code = cmdInstall(['--yes', '--settings', settings, '--zshrc', rc], { agents: ['claude'] });
+    assert.equal(code, 0);
+    assert.ok(!existsSync(join(dir, 'config.fish')), 'no fish evidence, no fish config');
+  } finally {
+    if (prevFish === undefined) delete process.env.UNSNOOZE_FISH_CONFIG; else process.env.UNSNOOZE_FISH_CONFIG = prevFish;
+    if (prevShell === undefined) delete process.env.SHELL; else process.env.SHELL = prevShell;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('cmdUninstall removes the fish block and nothing else', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-uninstall-'));
+  try {
+    const settings = join(dir, 'settings.json');
+    const fishrc = join(dir, 'config.fish');
+    writeFileSync(fishrc, '# keep me\n');
+    cmdInstall(['--yes', '--settings', settings, '--fishrc', fishrc], { agents: ['claude'] });
+    const code = cmdUninstall(['--fishrc', fishrc]);
+    assert.equal(code, 0);
+    const after = readFileSync(fishrc, 'utf-8');
+    assert.ok(!after.includes('# >>> unsnooze >>>'));
+    assert.ok(!after.includes('function claude'));
+    assert.match(after, /# keep me/, 'user content is preserved');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('cmdUninstall removes fish block created by login-shell install', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-uninstall2-'));
+  const prevFish = process.env.UNSNOOZE_FISH_CONFIG;
+  const prevShell = process.env.SHELL;
+  try {
+    process.env.UNSNOOZE_FISH_CONFIG = join(dir, 'config.fish');
+    process.env.SHELL = '/usr/bin/fish';
+    const settings = join(dir, 'settings.json');
+    cmdInstall(['--yes', '--settings', settings], { agents: ['claude'] });
+    assert.ok(readFileSync(join(dir, 'config.fish'), 'utf-8').includes('# >>> unsnooze >>>'));
+    cmdUninstall([]);
+    assert.ok(!readFileSync(join(dir, 'config.fish'), 'utf-8').includes('# >>> unsnooze >>>'));
+  } finally {
+    if (prevFish === undefined) delete process.env.UNSNOOZE_FISH_CONFIG; else process.env.UNSNOOZE_FISH_CONFIG = prevFish;
+    if (prevShell === undefined) delete process.env.SHELL; else process.env.SHELL = prevShell;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a fish wrapper actually routes, guards, and propagates exit status (skipped without fish)', () => {
+  let fish = null;
+  try { fish = execFileSync('which', ['fish'], { encoding: 'utf-8' }).trim(); } catch { /* absent */ }
+  if (!fish) return;
+  const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-live-'));
+  try {
+    const fakeBin = join(dir, 'unsnooze.js');
+    writeFileSync(fakeBin, 'process.stdout.write(JSON.stringify(process.argv.slice(2)));process.exit(7);\n');
+    const block = fishWrapperBlock(['claude'], fakeBin);
+    const cfg = join(dir, 'config.fish');
+    writeFileSync(cfg, block);
+
+    // Routes through unsnooze with argv intact.
+    const routed = execFileSync(fish, ['-c', `source ${cfg}; claude hello "two words"; echo "exit=$status"`],
+      { encoding: 'utf-8', env: { ...process.env, UNSNOOZE_ACTIVE: '' } });
+    assert.match(routed, /"_run"/);
+    assert.match(routed, /"claude"/, 'the _run argument stays the agent id');
+    assert.match(routed, /"two words"/, 'argv quoting must survive fish expansion');
+    assert.match(routed, /exit=7/, 'exit status must propagate');
+
+    // Recursion guard: an active unsnooze run falls back to the real CLI.
+    const guarded = execFileSync(fish, ['-c', `set -gx UNSNOOZE_ACTIVE 1; source ${cfg}; type -q claude; and echo shadowed`],
+      { encoding: 'utf-8' });
+    assert.match(guarded, /shadowed/, 'the wrapper function must still be defined under the guard');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/fish-install.test.js
+++ b/test/fish-install.test.js
@@ -4,21 +4,40 @@
 // block, its own target selection, and uninstall coverage — everything
 // asserted here mirrors the zsh/bash cases in install.test.js.
 
-const AUTOSTART_ISOLATION = mkdtempSync(join(tmpdir(), 'unsnooze-fish-autostart-'));
-process.env.UNSNOOZE_LAUNCH_AGENTS_DIR = join(AUTOSTART_ISOLATION, 'LaunchAgents');
-process.env.UNSNOOZE_SYSTEMD_USER_DIR = join(AUTOSTART_ISOLATION, 'systemd');
-
-import { test } from 'node:test';
+import { test, after, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import os, { tmpdir } from 'node:os';
+import { syncBuiltinESMExports } from 'node:module';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 
-import {
+// Uninstall also removes other shell wrappers, hooks, and the daemon lock.
+// Resolve every default path inside this fixture before importing install.js.
+const PROFILE = mkdtempSync(join(tmpdir(), 'unsnooze-fish-profile-'));
+mock.method(os, 'homedir', () => PROFILE);
+syncBuiltinESMExports();
+for (const [name, path] of Object.entries({
+  UNSNOOZE_STATE_DIR: 'state', UNSNOOZE_CLAUDE_DIR: 'claude',
+  UNSNOOZE_GROK_DIR: 'grok', UNSNOOZE_QWEN_DIR: 'qwen',
+  UNSNOOZE_FISH_CONFIG: 'config.fish',
+  UNSNOOZE_LAUNCH_AGENTS_DIR: 'LaunchAgents', UNSNOOZE_SYSTEMD_USER_DIR: 'systemd',
+})) process.env[name] = join(PROFILE, path);
+
+const {
   cmdInstall, cmdUninstall, installFishBlock, fishWrapperBlock, stripFencedBlock,
-} from '../src/install.js';
+} = await import('../src/install.js');
 import { fishConfigPath } from '../src/fish.js';
+
+after(() => {
+  mock.restoreAll();
+  syncBuiltinESMExports();
+  rmSync(PROFILE, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+});
+
+// Native Windows install/uninstall also changes PowerShell and Task Scheduler.
+// Keep the fish integration cases on platforms that actually run fish.
+const installTest = (name, fn) => test(name, { skip: process.platform === 'win32' }, fn);
 
 test('fishConfigPath honors XDG_CONFIG_HOME (absolute only) and UNSNOOZE_FISH_CONFIG', () => {
   assert.equal(
@@ -76,10 +95,10 @@ test('installFishBlock is replace-don-append, like the POSIX twin', () => {
   assert.ok(second.content.includes('# my fish config'));
 });
 
-test('generated block parses as real fish (skipped when fish is not installed)', () => {
+test('generated block parses as real fish', t => {
   let fish = null;
   try { fish = execFileSync('which', ['fish'], { encoding: 'utf-8' }).trim(); } catch { /* absent */ }
-  if (!fish) return;
+  if (!fish) return t.skip('fish is not installed');
   const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-parse-'));
   try {
     const content = installFishBlock('', ['claude', 'codex', 'grok', 'qwen', 'kimi', 'opencode', 'agy', 'cursor']);
@@ -99,7 +118,7 @@ test('the fish block round-trips through stripFencedBlock for uninstall', () => 
   assert.match(content, /set -x EDITOR nvim/);
 });
 
-test('cmdInstall writes the fish config at --fishrc, backing up first', () => {
+installTest('cmdInstall writes the fish config at --fishrc, backing up first', () => {
   const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-install-'));
   try {
     const settings = join(dir, 'settings.json');
@@ -118,7 +137,7 @@ test('cmdInstall writes the fish config at --fishrc, backing up first', () => {
   }
 });
 
-test('cmdInstall creates config.fish when fish is the login shell', () => {
+installTest('cmdInstall creates config.fish when fish is the login shell', () => {
   const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-login-'));
   const prevFish = process.env.UNSNOOZE_FISH_CONFIG;
   const prevShell = process.env.SHELL;
@@ -140,7 +159,7 @@ test('cmdInstall creates config.fish when fish is the login shell', () => {
   }
 });
 
-test('cmdInstall leaves fish alone when there is no fish on the machine', () => {
+installTest('cmdInstall leaves fish alone when there is no fish on the machine', () => {
   const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-absent-'));
   const prevFish = process.env.UNSNOOZE_FISH_CONFIG;
   const prevShell = process.env.SHELL;
@@ -159,7 +178,7 @@ test('cmdInstall leaves fish alone when there is no fish on the machine', () => 
   }
 });
 
-test('cmdUninstall removes the fish block and nothing else', () => {
+installTest('cmdUninstall removes the fish block and nothing else', () => {
   const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-uninstall-'));
   try {
     const settings = join(dir, 'settings.json');
@@ -177,7 +196,7 @@ test('cmdUninstall removes the fish block and nothing else', () => {
   }
 });
 
-test('cmdUninstall removes fish block created by login-shell install', () => {
+installTest('cmdUninstall removes fish block created by login-shell install', () => {
   const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-uninstall2-'));
   const prevFish = process.env.UNSNOOZE_FISH_CONFIG;
   const prevShell = process.env.SHELL;
@@ -196,10 +215,10 @@ test('cmdUninstall removes fish block created by login-shell install', () => {
   }
 });
 
-test('a fish wrapper actually routes, guards, and propagates exit status (skipped without fish)', () => {
+test('a fish wrapper actually routes, guards, and propagates exit status', t => {
   let fish = null;
   try { fish = execFileSync('which', ['fish'], { encoding: 'utf-8' }).trim(); } catch { /* absent */ }
-  if (!fish) return;
+  if (!fish) return t.skip('fish is not installed');
   const dir = mkdtempSync(join(tmpdir(), 'unsnooze-fish-live-'));
   try {
     const fakeBin = join(dir, 'unsnooze.js');
@@ -209,7 +228,7 @@ test('a fish wrapper actually routes, guards, and propagates exit status (skippe
     writeFileSync(cfg, block);
 
     // Routes through unsnooze with argv intact.
-    const routed = execFileSync(fish, ['-c', `source ${cfg}; claude hello "two words"; echo "exit=$status"`],
+    const routed = execFileSync(fish, ['--no-config', '-c', `source '${cfg}'; claude hello "two words"; echo "exit=$status"`],
       { encoding: 'utf-8', env: { ...process.env, UNSNOOZE_ACTIVE: '' } });
     assert.match(routed, /"_run"/);
     assert.match(routed, /"claude"/, 'the _run argument stays the agent id');
@@ -217,7 +236,7 @@ test('a fish wrapper actually routes, guards, and propagates exit status (skippe
     assert.match(routed, /exit=7/, 'exit status must propagate');
 
     // Recursion guard: an active unsnooze run falls back to the real CLI.
-    const guarded = execFileSync(fish, ['-c', `set -gx UNSNOOZE_ACTIVE 1; source ${cfg}; type -q claude; and echo shadowed`],
+    const guarded = execFileSync(fish, ['--no-config', '-c', `set -gx UNSNOOZE_ACTIVE 1; source '${cfg}'; type -q claude; and echo shadowed`],
       { encoding: 'utf-8' });
     assert.match(guarded, /shadowed/, 'the wrapper function must still be defined under the guard');
   } finally {

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 const AUTOSTART_ISOLATION = mkdtempSync(join(tmpdir(), 'unsnooze-install-autostart-'));
 process.env.UNSNOOZE_LAUNCH_AGENTS_DIR = join(AUTOSTART_ISOLATION, 'LaunchAgents');
 process.env.UNSNOOZE_SYSTEMD_USER_DIR = join(AUTOSTART_ISOLATION, 'systemd');
+process.env.UNSNOOZE_FISH_CONFIG = join(AUTOSTART_ISOLATION, 'config.fish');
 
 import {
   cmdInstall, mergeHookIntoSettings, removeHookFromSettings, installZshrcBlock, stripFencedBlock,

--- a/test/part3-fixes.test.js
+++ b/test/part3-fixes.test.js
@@ -21,6 +21,7 @@ const DIR = mkdtempSync(join(tmpdir(), 'unsnooze-part3-'));
 // repointed the running job at a temp dir and broke its log paths).
 process.env.UNSNOOZE_LAUNCH_AGENTS_DIR = join(DIR, 'LaunchAgents-isolated');
 process.env.UNSNOOZE_SYSTEMD_USER_DIR = join(DIR, 'systemd-isolated');
+process.env.UNSNOOZE_FISH_CONFIG = join(DIR, 'config.fish');
 process.env.UNSNOOZE_STATE_DIR = DIR;
 process.env.UNSNOOZE_NOTIFICATIONS = 'off';
 process.env.UNSNOOZE_LOCK_TIMEOUT_MS = '400';   // keep lock-wait tests fast

--- a/website/app/docs/page.jsx
+++ b/website/app/docs/page.jsx
@@ -52,7 +52,8 @@ $ unsnooze setup`}</Shell>
               <p>The setup wizard asks which agents to guard and which toggles you want, then wires
                 everything up:</p>
               <ul>
-                <li><strong>Shell wrappers</strong> into <C>~/.zshrc</C> / <C>~/.bashrc</C> — after
+                <li><strong>Shell wrappers</strong> into <C>~/.zshrc</C> / <C>~/.bashrc</C> (or
+                  <C> ~/.config/fish/config.fish</C> for fish) — after
                   this, typing <C>claude</C> or <C>codex</C> runs the CLI inside a watched
                   multiplexer pane. You never call unsnooze directly to be protected.</li>
                 <li><strong>The Claude <C>StopFailure</C> hook</strong> — the authoritative

--- a/website/app/docs/troubleshooting/page.jsx
+++ b/website/app/docs/troubleshooting/page.jsx
@@ -65,7 +65,8 @@ export default function TroubleshootingDocsPage() {
                 problem from a wake problem, and they have different fixes.</p>
               <ul>
                 <li><strong>Typing <C>claude</C> starts nothing watched.</strong> The shell
-                  wrapper lives in <C>~/.zshrc</C> or <C>~/.bashrc</C>, so it only applies to
+                  wrapper lives in <C>~/.zshrc</C> or <C>~/.bashrc</C> (<C>~/.config/fish/config.fish</C>{' '}
+                  for fish), so it only applies to
                   shells started after <C>unsnooze setup</C> ran. Open a new terminal, then
                   confirm with <C>unsnooze doctor</C>. Nothing is protected until the wrapper is
                   loaded, because the wrapper is the entry point — you never invoke unsnooze

--- a/website/lib/faq-data.jsx
+++ b/website/lib/faq-data.jsx
@@ -67,10 +67,11 @@ export const FAQ = [
   },
   {
     q: 'What does it need?',
-    text: 'Node ≥ 20, on macOS, Linux or Windows. A multiplexer (tmux ≥ 3.2, Zellij, herdr or cmux) gives you pane-level watching; without one unsnooze runs headless and still resumes. Wrappers install into ~/.zshrc / ~/.bashrc, or your PowerShell $PROFILE; everything is reversible with unsnooze uninstall.',
+    text: 'Node ≥ 20, on macOS, Linux or Windows. A multiplexer (tmux ≥ 3.2, Zellij, herdr or cmux) gives you pane-level watching; without one unsnooze runs headless and still resumes. Wrappers install into ~/.zshrc / ~/.bashrc, ~/.config/fish/config.fish for fish, or your PowerShell $PROFILE; everything is reversible with unsnooze uninstall.',
     jsx: <>Node ≥ 20, on macOS, Linux or Windows. A multiplexer (tmux ≥ 3.2, Zellij, herdr or
       cmux) gives you pane-level watching; without one unsnooze runs headless and still
-      resumes. Wrappers install into <C>~/.zshrc</C> / <C>~/.bashrc</C>, or your PowerShell{' '}
+      resumes. Wrappers install into <C>~/.zshrc</C> / <C>~/.bashrc</C>,{' '}
+      <C>~/.config/fish/config.fish</C> for fish, or your PowerShell{' '}
       <C>$PROFILE</C>; everything is reversible with <C>unsnooze uninstall</C>.</>,
   },
 ];


### PR DESCRIPTION
## What this change does

This PR adds fish shell support. The wrappers installed into `~/.zshrc` and
`~/.bashrc` (PowerShell on Windows) only. A fish user got no wrapper, so their
`claude` and `codex` launches never routed through unsnooze.

After this change, `unsnooze setup` and `unsnooze install` also write the
wrapper into `~/.config/fish/config.fish`.

## How it works

- Fish shares no syntax with POSIX rc files. `name() { … }` is a parse error in
  fish, and `$?` is `$status`. The wrapper gets its own body in fish syntax.
- The block keeps the POSIX semantics. It has the `UNSNOOZE_ACTIVE` recursion
  guard, a fallback to the real CLI, and `_run <id>` routing. The fallback runs
  when the entry point file is gone.
- Install writes the block when `config.fish` exists, or when fish is the login
  shell. A machine with no fish sees no change.
- A re-run replaces the block. It never appends a second copy.
- `unsnooze uninstall` removes the block. The user content stays.
- `unsnooze doctor` counts the fish config as a wrapper site. A fish-only
  install passes the check.
- `XDG_CONFIG_HOME` moves the config path. A relative value is ignored, per the
  XDG spec. `--fishrc <path>` overrides the target (tests, CI).

## Files

| File | Change |
|---|---|
| `src/fish.js` | New leaf module. Resolves the fish config path. |
| `src/install.js` | Fish wrapper block. Install and uninstall wiring. `--fishrc` override. |
| `src/doctor.js` | The wrapper health check includes the fish config. |
| `test/fish-install.test.js` | 13 new tests. |
| `README.md`, `website/`, `CHANGELOG.md` | The docs now mention fish. |

## Tests

- `npm test`: 1284 tests pass, 13 new.
- The suite checks the generated block with `fish -n` when fish is installed.
  The suite skips this check without fish.
- One live fish test routes a command through the wrapper. It checks quoted
  arguments and the exit status.

## Manual checks (fish 4.8.1, Linux)

- `unsnooze install --yes` with fish as the login shell writes `config.fish`.
- `unsnooze doctor` reports "all clear".
- fish loads the wrapper. `functions -q claude` returns true.
- `unsnooze uninstall` removes the block. The user content stays.
