### PR TITLE
Stop the daemon.log mode test from depending on the developer's umask

### DIFF
--- a/test/state-hardening.test.js
+++ b/test/state-hardening.test.js
@@ -604,11 +604,12 @@ test('a file that appears after the first repair pass is still narrowed', { skip
   const out = execFileSync(process.execPath, ['--input-type=module', '-e', `
     process.env.UNSNOOZE_STATE_DIR = ${JSON.stringify(d)};
     const { updateState } = await import(${JSON.stringify(pathToFileURL(join(ROOT, 'src/state.js')).href)});
-    const { writeFileSync, statSync } = await import('node:fs');
+    const { writeFileSync, chmodSync, statSync } = await import('node:fs');
     const { join } = await import('node:path');
     const daemonLog = join(${JSON.stringify(d)}, 'daemon.log');
     updateState(s => s);                          // first repair pass
-    writeFileSync(daemonLog, 'as launchd would'); // arrives afterwards, 0644
+    writeFileSync(daemonLog, 'as launchd would'); // arrives afterwards...
+    chmodSync(daemonLog, 0o644);                  // ...at 0644, whatever our umask is
     const at = (statSync(daemonLog).mode & 0o777).toString(8);
     await new Promise(r => setTimeout(r, 20));
     updateState(s => s);                          // a later write re-checks


### PR DESCRIPTION
`npm test` fails on a clean clone here, and the reason is the ambient umask rather than anything in `src/`.

The late-arriving-file test in `test/state-hardening.test.js` creates `daemon.log` with `writeFileSync` and no explicit mode, so the file lands at `0666` minus whatever umask the machine happens to use. Its precondition then asserts `0644`, which only holds at umask 022:

```
umask 002 -> 664    umask 022 -> 644    umask 027 -> 640    umask 077 -> 600
```

Three of those four fail before reaching the assertion the test exists for:

```
not ok 1034 - a file that appears after the first repair pass is still narrowed
  error: precondition: nothing of ours created it
    '664' !== '644'
```

umask 002 is what you get on Debian and Ubuntu accounts with per-user groups, which is how I hit it.

`chmodSync` ignores the umask, so chmod-ing the file after writing it makes the simulated launchd log `0644` everywhere. The rest of this same file already reaches for `chmodSync` when it needs an exact mode, so this brings the one outlier in line.

Measured before the change, `node --test test/state-hardening.test.js`: 35 pass 1 fail at umask 002, 027 and 077; 36 pass at 022. After: 36 pass at all four. Full suite goes from 1270 pass 1 fail to 1271 pass 0 fail.

The narrowing behaviour the test was written to check is untouched — `r.after` still has to be `600`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
