### PR TITLE
fix(launcher): bypass multiplexer wrapping and monitoring for --help, --version, and print flags

### DIFF
--- a/bin/unsnooze.js
+++ b/bin/unsnooze.js
@@ -69,7 +69,7 @@ async function maybeLaunchExitNotice(args) {
   try {
     if (process.env.TMUX || process.env.ZELLIJ || process.env.UNSNOOZE_ACTIVE === '1') return;
     if (!process.stderr.isTTY) return;                            // pipes, CI, scripts
-    if (args.includes('-p') || args.includes('--print')) return;  // non-interactive runs
+    if (args.some(a => a === '-p' || a === '--print' || a === '-h' || a === '--help' || a === '-v' || a === '-V' || a === '--version')) return;  // non-interactive runs
     const mod = await safeImport('../src/update-check.js');
     if (!mod) return;
     const notice = mod.launchExitNotice();

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -2,7 +2,7 @@
 //   - outside a multiplexer: re-exec through its launchWrapped operation
 //   - inside one: spawn a detached per-pane monitor, then run the CLI,
 //     propagating its exit code
-//   - -p/--print: pure pass-through, no monitor (nothing interactive to scrape)
+//   - -p/--print, -h/--help, -v/-V/--version: pure pass-through, no monitor (nothing interactive to scrape)
 
 import { spawn, spawnSync } from 'node:child_process';
 import { getMultiplexer } from './multiplexer.js';
@@ -16,8 +16,12 @@ import { AgentDispatchedError, SessionCreateError, attachHint } from './multiple
 
 const log = makeLogger('launcher');
 
-function isPrintMode(args) {
-  return args.includes('-p') || args.includes('--print');
+export function isPassthrough(args = []) {
+  return args.some(a =>
+    a === '-p' || a === '--print'
+    || a === '-h' || a === '--help'
+    || a === '-v' || a === '-V' || a === '--version'
+  );
 }
 
 export function resolvePaneOwner(muxName, env = process.env) {
@@ -44,7 +48,12 @@ export function runLauncher(args, agentId = 'claude', { processBirthFn = process
   // Recursion / nested-launch guard: inside an unsnooze-managed session, a
   // plain `claude`/`codex`/`unsnooze` call goes straight through. Same for an
   // agent the user disabled in settings — run it, don't watch it.
-  if (process.env.UNSNOOZE_ACTIVE === '1' || isPrintMode(args) || !getConfig(`agents.${agent.id}`)) {
+  //
+  // Non-interactive / informational invocations (-p/--print, -h/--help, -v/--version)
+  // also bypass multiplexer wrapping and monitoring — running a new tmux session
+  // or spawning a watcher for `claude --help` flashes the screen and slows down
+  // simple queries.
+  if (process.env.UNSNOOZE_ACTIVE === '1' || isPassthrough(args) || !getConfig(`agents.${agent.id}`)) {
     const r = spawnSync(agent.bin, args, { stdio: 'inherit', env: { ...process.env, UNSNOOZE_ACTIVE: '1' } });
     return r.status ?? 1;
   }

--- a/test/launcher-passthrough.test.js
+++ b/test/launcher-passthrough.test.js
@@ -16,6 +16,10 @@ const REAL_BIN = fileURLToPath(new URL('../bin/unsnooze.js', import.meta.url));
 const DIR = mkdtempSync(join(tmpdir(), 'unsnooze-passthrough-'));
 const SHIMS = join(DIR, 'shims');
 mkdirSync(SHIMS);
+const AGENT = join(SHIMS, 'claude');
+// GNU echo handles --help/--version itself. This stub always prints argv.
+writeFileSync(AGENT, '#!/bin/sh\nprintf \'%s\\n\' "$@"\n');
+chmodSync(AGENT, 0o755);
 
 after(() => rmSync(DIR, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }));
 
@@ -51,7 +55,7 @@ function run(args = ['_run', 'claude', '--help'], extraEnv = {}) {
       ...process.env,
       PATH: `${SHIMS}:/usr/bin:/bin`,
       UNSNOOZE_STATE_DIR: join(DIR, 'state'),
-      UNSNOOZE_CLAUDE_BIN: '/bin/echo',
+      UNSNOOZE_CLAUDE_BIN: AGENT,
       UNSNOOZE_MULTIPLEXER: 'tmux',
       TMUX: '', ZELLIJ: '', UNSNOOZE_ACTIVE: '',
       ...extraEnv,

--- a/test/launcher-passthrough.test.js
+++ b/test/launcher-passthrough.test.js
@@ -1,0 +1,82 @@
+import { test as baseTest, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { isPassthrough } from '../src/launcher.js';
+
+const test = process.platform === 'win32'
+  ? (name, fn) => baseTest(name, { skip: 'unix-only surface (sh/PATH/tmux)' }, fn)
+  : baseTest;
+
+const REAL_BIN = fileURLToPath(new URL('../bin/unsnooze.js', import.meta.url));
+const DIR = mkdtempSync(join(tmpdir(), 'unsnooze-passthrough-'));
+const SHIMS = join(DIR, 'shims');
+mkdirSync(SHIMS);
+
+after(() => rmSync(DIR, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }));
+
+test('isPassthrough identifies informational and non-interactive flags', () => {
+  for (const flag of ['--help', '-h', '--version', '-v', '-V', '-p', '--print']) {
+    assert.equal(isPassthrough([flag]), true, `expected ${flag} to be passthrough`);
+    assert.equal(isPassthrough(['foo', flag, 'bar']), true, `expected embedded ${flag} to be passthrough`);
+  }
+  assert.equal(isPassthrough([]), false);
+  assert.equal(isPassthrough(['hey']), false);
+  assert.equal(isPassthrough(['-c']), false);
+  assert.equal(isPassthrough(['--resume', '123']), false);
+  assert.equal(isPassthrough(['--dangerously-skip-permissions']), false);
+});
+
+function installTmuxShim(newSessionBody = 'exit 1') {
+  const shim = join(SHIMS, 'tmux');
+  writeFileSync(shim, `#!/bin/sh
+case "$1" in
+  -V) echo "tmux 3.7b"; exit 0 ;;
+  has-session) exit 1 ;;
+  new-session) ${newSessionBody} ;;
+  *) exit 0 ;;
+esac
+`);
+  chmodSync(shim, 0o755);
+}
+
+function run(args = ['_run', 'claude', '--help'], extraEnv = {}) {
+  return spawnSync(process.execPath, [REAL_BIN, ...args], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      PATH: `${SHIMS}:/usr/bin:/bin`,
+      UNSNOOZE_STATE_DIR: join(DIR, 'state'),
+      UNSNOOZE_CLAUDE_BIN: '/bin/echo',
+      UNSNOOZE_MULTIPLEXER: 'tmux',
+      TMUX: '', ZELLIJ: '', UNSNOOZE_ACTIVE: '',
+      ...extraEnv,
+    },
+  });
+}
+
+test('claude --help runs plain agent directly without wrapping into multiplexer', () => {
+  // If launcher attempts to wrap into tmux, new-session will fail with exit 42
+  installTmuxShim('echo "tmux should not be called for --help" >&2; exit 42');
+
+  for (const flag of ['--help', '-h', '--version', '-v', '-V']) {
+    const r = run(['_run', 'claude', flag]);
+    assert.equal(r.status, 0, `expected exit 0 for ${flag}, got ${r.status}: ${r.stderr}`);
+    assert.equal(r.stdout, `${flag}\n`, `agent gets ${flag} untouched`);
+    assert.doesNotMatch(r.stderr, /without limit-watch|tmux should not be called/,
+      `${flag} should be intentional passthrough, not fallback`);
+  }
+});
+
+test('claude --help does not prepend launchExtraArgs', () => {
+  installTmuxShim('exit 42');
+  const r = run(['_run', 'claude', '--help'], {
+    UNSNOOZE_LAUNCH_EXTRA_ARGS_CLAUDE: '--autocompact 400000',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout, '--help\n', 'launchExtraArgs must not be prepended on --help');
+});


### PR DESCRIPTION
### Summary

When invoking agent CLIs via the unsnooze shell wrapper (or directly via `unsnooze _run <agent> ...`), informational flags like `--help`, `-h`, `--version`, `-v`, and `-V` were previously treated as interactive sessions.

This resulted in:
1. Spawning a new multiplexer window/session (e.g. tmux) just to print help text when run outside a multiplexer.
2. Prepending `launchExtraArgs` (e.g. `--autocompact`) to `--help` queries.
3. Allocating lease records and spawning background monitor processes for quick queries.
4. Potentially printing update notices on exit after help output.

### Fix
- Updated `isPassthrough` in `src/launcher.js` to include `-h`, `--help`, `-v`, `-V`, `--version`, `-p`, and `--print`.
- Bypassed multiplexer session creation, monitoring, and `launchExtraArgs` prepending for all passthrough invocations, delegating directly to `spawnSync(agent.bin, args)`.
- Suppressed exit update notices in `bin/unsnooze.js` for passthrough invocations.
- Added test coverage in `test/launcher-passthrough.test.js`.