### PR TITLE
fix(codex): detect quota stops after empty premium snapshots

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -22,7 +22,7 @@ import {
 } from './config.js';
 import { getMultiplexer } from './multiplexer.js';
 import { parseTranscriptLine } from './watchers/claude.js';
-import { parseRolloutLine, rolloutMeta } from './watchers/codex.js';
+import { parseRolloutLines, rolloutMeta } from './watchers/codex.js';
 import { ROLLOUT_RE } from './agents/codex.js';
 import { parseResetTime, resetAtMs } from './time-parser.js';
 import { upsertSession, readState, updateState } from './state.js';
@@ -85,8 +85,8 @@ export function codexSource({ roots }) {
     roots,
     enabled: () => getConfig('agents.codex'),
     match: p => ROLLOUT_RE.test(basename(p)),
-    parse(lines, path) {
-      const hits = lines.map(parseRolloutLine).filter(Boolean);
+    parse(lines, path, { offset } = {}) {
+      const hits = parseRolloutLines(lines, { path, offset });
       if (hits.length === 0) return [];
       const last = hits[hits.length - 1];   // the latest snapshot governs
       const meta = rolloutMeta(path);
@@ -322,7 +322,10 @@ export function createWatcher({
     const lastNl = buf.lastIndexOf(0x0a);
     if (lastNl === -1) { setOffset(path, offset); return null; }  // partial line — wait
     setOffset(path, offset + lastNl + 1);
-    return buf.subarray(0, lastNl + 1).toString('utf-8').split('\n').filter(l => l.trim());
+    return {
+      offset,
+      lines: buf.subarray(0, lastNl + 1).toString('utf-8').split('\n').filter(l => l.trim()),
+    };
   }
 
   function walk(dir, depth, cb) {
@@ -353,11 +356,12 @@ export function createWatcher({
             const usageMatch = source.usageMatch ? source.usageMatch(path) : stopMatch;
             if (!stopMatch && !usageMatch) return;
             seen.add(path);
-            const lines = readAppended(path);
-            if (!lines || lines.length === 0) return;
+            const appended = readAppended(path);
+            if (!appended || appended.lines.length === 0) return;
+            const { lines, offset } = appended;
             if (stopMatch) {
               try {
-                candidates.push(...source.parse(lines, path));
+                candidates.push(...source.parse(lines, path, { offset }));
               } catch (err) {
                 log(`parse error in ${path}: ${err.message}`);
               }

--- a/src/watchers/codex.js
+++ b/src/watchers/codex.js
@@ -23,17 +23,29 @@ export { extractCodexUsage } from '../usage.js';
 // must not conflate it with the weekly bucket.
 import { labelWindow } from '../usage.js';
 
-// One rollout JSONL line → limit-stop candidate or null. A window binds when
-// its used_percent hits 100 (or rate_limit_reached_type says the model was
-// actually blocked); with several exhausted windows the LATEST reset governs —
-// resuming at the earlier one would immediately re-hit the other limit.
-export function parseRolloutLine(line) {
+function rolloutSnapshot(line) {
   if (!line || !line.trim()) return null;
   let entry;
   try { entry = JSON.parse(line); } catch { return null; }
   if (entry?.type !== 'event_msg' || entry.payload?.type !== 'token_count') return null;
   const rl = entry.payload.rate_limits;
   if (!rl || typeof rl !== 'object') return null;
+  return entry;
+}
+
+function emptyPremium(rl) {
+  return rl.limit_id === 'premium' && rl.primary === null && rl.secondary === null
+    && rl.credits?.has_credits === false && rl.credits?.unlimited === false
+    && rl.credits?.balance != null && rl.credits.balance !== ''
+    && Number(rl.credits.balance) === 0;
+}
+
+// With several exhausted windows, the latest reset governs: resuming at an
+// earlier one would immediately hit the other limit again.
+function parseSnapshot(entry, previous = null) {
+  if (!entry) return null;
+  const rl = entry.payload.rate_limits;
+  const ts = entry.timestamp ? Date.parse(entry.timestamp) : NaN;
 
   const windows = ['primary', 'secondary']
     .map(k => rl[k])
@@ -48,15 +60,76 @@ export function parseRolloutLine(line) {
       ? named
       : windows.reduce((a, b) => ((b.resets_at || 0) > (a?.resets_at || 0) ? b : a), null);
   }
+  // #20: Codex can stop at a reported 99%, then emit an empty premium bucket
+  // instead of a 100% snapshot. Infer a stop only for that transition,
+  // in the same rollout, within a minute, with no credits and a future reset.
+  // A lone 99% snapshot or an unrelated premium bucket is not a stop.
+  if (!binding && emptyPremium(rl) && previous) {
+    const prior = previous.payload.rate_limits;
+    const elapsed = ts - Date.parse(previous.timestamp);
+    const primary = prior.primary;
+    if (prior.limit_id === 'codex' && elapsed >= 0 && elapsed <= 60_000
+        && primary?.window_minutes === 300
+        && Number.isFinite(primary.used_percent) && primary.used_percent >= 99
+        && Number.isFinite(primary.resets_at) && primary.resets_at * 1000 > ts) {
+      binding = primary;
+      const secondary = prior.secondary;
+      if (Number.isFinite(secondary?.used_percent) && secondary.used_percent >= 100
+          && Number.isFinite(secondary.resets_at) && secondary.resets_at > binding.resets_at) {
+        binding = secondary;
+      }
+    }
+  }
   if (!binding) return null;
 
-  const ts = entry.timestamp ? Date.parse(entry.timestamp) : NaN;
   return {
     limitType: labelWindow(binding.window_minutes),
     resetAt: binding.resets_at ? binding.resets_at * 1000 : null,
     reachedType: rl.rate_limit_reached_type || null,
     timestampMs: Number.isFinite(ts) ? ts : null,
   };
+}
+
+export function parseRolloutLine(line) {
+  return parseSnapshot(rolloutSnapshot(line));
+}
+
+// Look immediately before the appended batch, not at the file's current EOF:
+// it may have grown since the watcher read it. This also works after restart
+// without persisting another cache alongside the watcher's byte offsets.
+function previousSnapshot(path, offset) {
+  if (!path || !Number.isSafeInteger(offset) || offset <= 0) return null;
+  let fd;
+  try {
+    fd = openSync(path, 'r');
+    const length = Math.min(offset, 4 * 1024 * 1024);
+    const buf = Buffer.alloc(length);
+    const count = readSync(fd, buf, 0, length, offset - length);
+    const lines = buf.subarray(0, count).toString('utf-8').split('\n');
+    if (offset > length) lines.shift(); // the first line may be truncated
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const snapshot = rolloutSnapshot(lines[i]);
+      if (snapshot) return snapshot;
+    }
+  } catch { /* missing context means no inferred stop */ }
+  finally { if (fd !== undefined) closeSync(fd); }
+  return null;
+}
+
+export function parseRolloutLines(lines, { path, offset } = {}) {
+  let previous;
+  const hits = [];
+  for (const line of lines) {
+    const snapshot = rolloutSnapshot(line);
+    if (!snapshot) continue;
+    if (previous === undefined && emptyPremium(snapshot.payload.rate_limits)) {
+      previous = previousSnapshot(path, offset);
+    }
+    const hit = parseSnapshot(snapshot, previous);
+    if (hit) hits.push(hit);
+    previous = snapshot;
+  }
+  return hits;
 }
 
 // The session_meta head line can be very long (it embeds the full base

--- a/test/codex-premium-limit.test.js
+++ b/test/codex-premium-limit.test.js
@@ -1,0 +1,138 @@
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const DIR = mkdtempSync(join(tmpdir(), 'unsnooze-codex-premium-'));
+process.env.UNSNOOZE_STATE_DIR = join(DIR, 'state');
+process.env.UNSNOOZE_CLAUDE_DIR = join(DIR, 'claude');
+process.env.UNSNOOZE_CODEX_DIR = join(DIR, 'codex');
+process.env.UNSNOOZE_NOTIFICATIONS = 'off';
+process.env.UNSNOOZE_MULTIPLEXER = 'headless';
+process.env.UNSNOOZE_AUTO_RESUME = 'true';
+
+const { parseRolloutLines } = await import('../src/watchers/codex.js');
+const { createWatcher, codexSource } = await import('../src/watcher.js');
+const { readState } = await import('../src/state.js');
+const { dueForDispatch } = await import('../src/resumer.js');
+const { buildUsageReport, extractCodexUsage } = await import('../src/usage.js');
+const { RESET_MARGIN_MS } = await import('../src/config.js');
+after(() => rmSync(DIR, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }));
+
+// Issue #20: the two consecutive snapshots at the enforced five-hour limit.
+const BEFORE = Date.parse('2026-09-05T13:48:36.539Z');
+const BLOCKED = Date.parse('2026-09-05T13:48:37.162Z');
+const RESET = 1788631754;
+function snapshot(rateLimits, at = BEFORE) {
+  return JSON.stringify({ timestamp: new Date(at).toISOString(), type: 'event_msg',
+    payload: { type: 'token_count', rate_limits: rateLimits } });
+}
+function normal(overrides = {}, at = BEFORE) {
+  return snapshot({ limit_id: 'codex',
+    primary: { used_percent: 99, window_minutes: 300, resets_at: RESET },
+    secondary: { used_percent: 32, window_minutes: 10080, resets_at: 1788751350 },
+    plan_type: 'plus', rate_limit_reached_type: null, ...overrides }, at);
+}
+function premium(overrides = {}, at = BLOCKED) {
+  return snapshot({ limit_id: 'premium', primary: null, secondary: null,
+    credits: { has_credits: false, unlimited: false, balance: '0' },
+    plan_type: 'plus', rate_limit_reached_type: null, ...overrides }, at);
+}
+
+test('99% followed by empty premium records the known five-hour reset', () => {
+  const hits = parseRolloutLines([normal(), premium()]);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].limitType, '5h');
+  assert.equal(hits[0].resetAt, RESET * 1000);
+  assert.equal(hits[0].timestampMs, BLOCKED);
+  // The empty bucket must not erase or reduce the latest exact usage.
+  const report = buildUsageReport({ now: BLOCKED,
+    codexSamples: [normal(), premium()].map(extractCodexUsage).filter(Boolean) });
+  assert.equal(report.agents.find(a => a.agent === 'codex').windows[0].ladder.pct, 99);
+});
+
+test('99% alone, other buckets, stale context, and available credits do not infer stops', () => {
+  const cases = [
+    [normal()], [premium()],
+    [normal({ limit_id: 'other' }), premium()],
+    [normal({ primary: { used_percent: 98, window_minutes: 300, resets_at: RESET } }), premium()],
+    [normal({ primary: { used_percent: 99, window_minutes: 10080, resets_at: RESET } }), premium()],
+    [normal({ primary: { used_percent: 99, window_minutes: 300, resets_at: BEFORE / 1000 } }), premium()],
+    [normal({}, BLOCKED - 60_001), premium()],
+    [normal({}, BLOCKED + 1), premium()],
+    [normal(), premium({ limit_id: 'other' })],
+    [normal(), premium({ credits: { has_credits: true, unlimited: false, balance: '0' } })],
+    [normal(), premium({ credits: { has_credits: false, unlimited: true, balance: '0' } })],
+    [normal(), premium({ credits: { has_credits: false, unlimited: false, balance: '5' } })],
+    [normal(), premium({ credits: { has_credits: false, unlimited: false, balance: null } })],
+    [normal(), normal({ primary: { used_percent: 3, window_minutes: 300, resets_at: RESET } }), premium()],
+    [normal(), snapshot({ limit_id: 'other', primary: null, secondary: null }), premium()],
+  ];
+  for (const lines of cases) assert.deepEqual(parseRolloutLines(lines), [], lines.join('\n'));
+  const invalidTimestamp = JSON.parse(normal());
+  invalidTimestamp.timestamp = 'invalid';
+  assert.deepEqual(parseRolloutLines([JSON.stringify(invalidTimestamp), premium()]), []);
+});
+
+test('an exhausted weekly window still controls the later reset', () => {
+  const hits = parseRolloutLines([normal({
+    secondary: { used_percent: 100, window_minutes: 10080, resets_at: RESET + 86400 },
+  }), premium()]);
+  assert.equal(hits.at(-1).limitType, 'weekly');
+  assert.equal(hits.at(-1).resetAt, (RESET + 86400) * 1000);
+});
+
+function setup(name) {
+  const root = join(DIR, name);
+  mkdirSync(root);
+  const sessionId = name;
+  const file = join(root, 'rollout-2026-09-05-12345678-1234-1234-1234-123456789abc.jsonl');
+  const meta = JSON.stringify({ type: 'session_meta', payload: {
+    id: sessionId, cwd: root, originator: 'codex_desktop',
+  } }) + '\n';
+  const makeWatcher = extra => createWatcher({
+    sources: [codexSource({ roots: [root] })], offsetsPath: join(root, 'offsets.json'),
+    now: () => BLOCKED, ...extra,
+  });
+  return { root, file, meta, makeWatcher, sessionId };
+}
+
+test('a stop across polls survives restart and becomes due only after reset plus margin', async () => {
+  const { file, meta, makeWatcher, sessionId } = setup('restart');
+  writeFileSync(file, meta);
+  const watcher = makeWatcher();
+  await watcher.tick();
+  appendFileSync(file, normal() + '\n');
+  assert.equal(await watcher.tick(), 0);
+  const restarted = makeWatcher();
+  appendFileSync(file, premium() + '\n');
+  assert.equal(await restarted.tick(), 1);
+  const record = Object.values(readState().sessions).find(s => s.sessionId === sessionId);
+  assert.equal(record.status, 'stopped');
+  assert.equal(record.origin, 'codex_desktop');
+  assert.equal(record.resetAt, RESET * 1000 + RESET_MARGIN_MS);
+  assert.equal(record.resetSource, 'absolute');
+  assert.ok(!dueForDispatch(record.resetAt - 1).some(s => s.sessionId === sessionId));
+  assert.ok(dueForDispatch(record.resetAt).some(s => s.sessionId === sessionId));
+  appendFileSync(file, premium({}, BLOCKED + 1000) + '\n');
+  assert.equal(await restarted.tick(), 0, 'repeated empty premium is not a new transition');
+});
+
+test('cold-start context can explain a new stop without replaying history', async () => {
+  const { file, meta, makeWatcher } = setup('cold');
+  writeFileSync(file, meta + normal() + '\n');
+  const watcher = makeWatcher({ onStop: () => {} });
+  assert.equal(await watcher.tick(), 0);
+  appendFileSync(file, premium() + '\n');
+  assert.equal(await watcher.tick(), 1);
+  assert.equal(await watcher.tick(), 0);
+});
+
+test('context comes from the same file and never from after the batch offset', () => {
+  const { file, meta } = setup('offset');
+  writeFileSync(file, meta + premium() + '\n' + normal() + '\n');
+  assert.deepEqual(parseRolloutLines([premium()], { path: file, offset: Buffer.byteLength(meta) }), []);
+  assert.deepEqual(parseRolloutLines([premium()], { path: join(DIR, 'missing'), offset: 100 }), []);
+  assert.deepEqual(parseRolloutLines([premium()], { path: file, offset: 0 }), []);
+});


### PR DESCRIPTION
Codex can stop at 99% usage and then write an empty premium bucket. The watcher now recognizes that transition and uses the last five-hour reset time to schedule the session.

The fallback requires consecutive rate-limit snapshots from the same rollout, no more than a minute apart, no available credits, and a future reset. Context is read before the saved file offset, so it also works across watcher polls and daemon restarts. An exhausted weekly window still takes precedence when its reset is later.

All 1,277 tests pass locally on Node 22. New coverage checks the reported sequence, saved stop and resume timing, restarts, cold starts, and cases that must not create a stop. The separate 64% usage reading was not reproduced; the supplied sequence retains 99% in the usage report.

Fixes #20.
